### PR TITLE
Improve Hermes one-step setup integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Wraps the existing [ClawRouter](https://github.com/BlockRunAI/ClawRouter) TypeSc
 ```bash
 pip install hermes-plugin-clawrouter
 hermes plugins enable clawrouter
-hermes clawrouter setup
-hermes clawrouter doctor
+hermes-clawrouter setup
+hermes-clawrouter doctor
 ```
 
-`setup` writes the model-provider plugin to `~/.hermes/plugins/model-providers/clawrouter/` (Hermes only loads provider plugins from that directory; PyPI entry points can't ship them).
+`setup` writes the model-provider plugin to `~/.hermes/plugins/model-providers/clawrouter/`, seeds `CLAWROUTER_API_KEY=clawrouter-local` in `~/.hermes/.env`, and registers ClawRouter in `~/.hermes/config.yaml` so Hermes' `/model` picker can show the provider and curated BlockRun chat models.
+
+`hermes-clawrouter` is provided because some Hermes releases do not add plugin-defined top-level CLI commands before the plugin is enabled. Once the plugin is loaded, `hermes clawrouter <setup|wallet|doctor|route|stats>` may also be available.
 
 ## Usage
 
@@ -57,7 +59,7 @@ Set `BLOCKRUN_WALLET_KEY=<0x raw EVM hex>` to bypass the mnemonic file (EVM-only
 ## How it works
 
 1. `hermes` starts → the entry-point plugin is loaded → `register(ctx)` wires tools, slash commands, CLI, and the skill.
-2. `hermes clawrouter setup` materializes `~/.hermes/plugins/model-providers/clawrouter/{plugin.yaml,__init__.py}` from bundled package data.
+2. `hermes-clawrouter setup` materializes `~/.hermes/plugins/model-providers/clawrouter/{plugin.yaml,__init__.py}` from bundled package data and writes Hermes config/env hints needed by current Hermes provider and gateway model-picker paths.
 3. Hermes' `providers/__init__.py` discovers the materialized directory and registers the `ClawRouterProfile`, pointing `base_url` at `http://127.0.0.1:<port>/v1`.
 4. First tool call or chat turn → the supervisor probes `:8402`, spawns `npx -y @blockrun/clawrouter --port <port>` if needed, waits ≤30s for `/v1/models`, then forwards the request.
 5. A heartbeat thread restarts the subprocess on death (max 3 restarts/min).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "httpx>=0.27",
     "bip_utils>=2.9",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -36,7 +37,10 @@ dev = [
 ]
 
 [project.entry-points."hermes_agent.plugins"]
-clawrouter = "clawrouter_hermes:register"
+clawrouter = "clawrouter_hermes"
+
+[project.scripts]
+hermes-clawrouter = "clawrouter_hermes.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/BlockRunAI/ClawRouter"

--- a/src/clawrouter_hermes/__init__.py
+++ b/src/clawrouter_hermes/__init__.py
@@ -32,6 +32,7 @@ _VERSION = "0.1.0"
 
 def register(ctx) -> None:
     """Wire all surfaces into the Hermes plugin context."""
+    _install_compat()
     _register_tools(ctx)
     _register_slash_command(ctx)
     _register_cli(ctx)
@@ -46,6 +47,15 @@ def register(ctx) -> None:
             logger.debug("clawrouter: proxy not yet running (will spawn on first use)")
     except Exception as exc:
         logger.debug("clawrouter: startup probe failed: %s", exc)
+
+
+def _install_compat() -> None:
+    """Best-effort setup for Hermes versions that need provider/config hints."""
+    try:
+        _cli.install_hermes_compat()
+        _cli.patch_hermes_model_catalog()
+    except Exception as exc:
+        logger.debug("clawrouter: compatibility setup skipped: %s", exc)
 
 
 def _register_tools(ctx) -> None:

--- a/src/clawrouter_hermes/cli.py
+++ b/src/clawrouter_hermes/cli.py
@@ -19,7 +19,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
-from . import proxy_supervisor, state, tools, wallet
+from . import models, proxy_supervisor, state, tools, wallet
 
 
 def _hermes_home() -> Path:
@@ -36,6 +36,14 @@ def _hermes_home() -> Path:
 
 def _provider_plugin_dir() -> Path:
     return _hermes_home() / "plugins" / "model-providers" / "clawrouter"
+
+
+def _env_file() -> Path:
+    return _hermes_home() / ".env"
+
+
+def _config_file() -> Path:
+    return _hermes_home() / "config.yaml"
 
 
 def __getattr__(name: str):
@@ -115,6 +123,15 @@ def _setup(args: argparse.Namespace) -> None:
         _materialize_provider_plugin(force=args.force)
         print(f"✓ Wrote model-provider plugin to {_provider_plugin_dir()}")
 
+    _ensure_local_api_key()
+    print(f"✓ Ensured CLAWROUTER_API_KEY in {_env_file()}")
+
+    config_changed = _configure_hermes_provider(set_default=True)
+    if config_changed:
+        print(f"✓ Registered ClawRouter in {_config_file()} for /model picker support")
+    else:
+        print(f"✓ ClawRouter already registered in {_config_file()}")
+
     if shutil.which("npx") is None:
         print("✗ `npx` not found on PATH.")
         print("  Install Node.js 18+ from https://nodejs.org and re-run setup.")
@@ -135,7 +152,8 @@ def _setup(args: argparse.Namespace) -> None:
         print("  Run: npx @blockrun/clawrouter setup")
 
     print()
-    print("Next: open a Hermes chat with model `blockrun/auto` and ask anything.")
+    print("Next: restart any running Hermes gateway, then choose ClawRouter in /model or run:")
+    print("  hermes --provider clawrouter -m blockrun/auto")
 
 
 def _materialize_provider_plugin(*, force: bool) -> None:
@@ -160,6 +178,98 @@ def _materialize_provider_plugin(*, force: bool) -> None:
                 "This indicates a broken package install."
             ) from exc
         (_provider_plugin_dir() / dst_name).write_text(data, encoding="utf-8")
+
+
+def _ensure_local_api_key() -> None:
+    """Seed a harmless local bearer so Hermes treats ClawRouter as configured."""
+    os.environ.setdefault("CLAWROUTER_API_KEY", "clawrouter-local")
+    path = _env_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if "CLAWROUTER_API_KEY=" in existing:
+        return
+    prefix = existing.rstrip()
+    suffix = "\n" if prefix else ""
+    path.write_text(f"{prefix}{suffix}CLAWROUTER_API_KEY=clawrouter-local\n", encoding="utf-8")
+
+
+def _configure_hermes_provider(*, set_default: bool = False) -> bool:
+    """Add ClawRouter to Hermes config so gateway /model can list it."""
+    try:
+        import yaml  # type: ignore
+    except Exception:
+        return False
+
+    path = _config_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    raw = path.read_text(encoding="utf-8") if path.exists() else ""
+    config = yaml.safe_load(raw) if raw.strip() else {}
+    if not isinstance(config, dict):
+        config = {}
+
+    changed = False
+    model_cfg = config.setdefault("model", {})
+    if set_default and isinstance(model_cfg, dict):
+        for key, value in {
+            "default": "blockrun/auto",
+            "provider": "clawrouter",
+            "base_url": _base_url(),
+        }.items():
+            if model_cfg.get(key) != value:
+                model_cfg[key] = value
+                changed = True
+
+    providers = config.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        providers = {}
+        config["providers"] = providers
+        changed = True
+
+    desired = {
+        "name": "ClawRouter",
+        "base_url": _base_url(),
+        "key_env": "CLAWROUTER_API_KEY",
+        "transport": "openai_chat",
+        "default_model": "blockrun/auto",
+        "discover_models": False,
+        "models": models.chat_models(),
+    }
+    current = providers.get("clawrouter")
+    if not isinstance(current, dict):
+        providers["clawrouter"] = desired
+        changed = True
+    else:
+        for key, value in desired.items():
+            if current.get(key) != value:
+                current[key] = value
+                changed = True
+
+    if changed or not path.exists():
+        path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return changed
+
+
+def _base_url() -> str:
+    return os.environ.get("CLAWROUTER_PROXY_URL", "http://127.0.0.1:8402/v1").rstrip("/")
+
+
+def install_hermes_compat(*, force_provider: bool = False, set_default: bool = False) -> None:
+    """Best-effort one-shot install for Hermes plugin/provider integration."""
+    if force_provider or not _provider_plugin_dir().exists():
+        _materialize_provider_plugin(force=force_provider)
+    _ensure_local_api_key()
+    _configure_hermes_provider(set_default=set_default)
+
+
+def patch_hermes_model_catalog() -> None:
+    """Expose ClawRouter models to Hermes' in-process /model picker."""
+    try:
+        from hermes_cli import models as hermes_models  # type: ignore
+    except Exception:
+        return
+    provider_models = getattr(hermes_models, "_PROVIDER_MODELS", None)
+    if isinstance(provider_models, dict):
+        provider_models["clawrouter"] = models.chat_models()
 
 
 def _wallet(args: argparse.Namespace) -> None:
@@ -252,3 +362,10 @@ def _route(args: argparse.Namespace) -> None:
 
 def _stats(_: argparse.Namespace) -> None:
     print(json.dumps(tools.proxy_stats(), indent=2))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="hermes-clawrouter")
+    register_cli(parser)
+    args = parser.parse_args(argv)
+    clawrouter_command(args)

--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -1,0 +1,27 @@
+"""Starter ClawRouter chat model catalog for Hermes pickers.
+
+The full BlockRun catalog is maintained by the ClawRouter service. This list is
+intentionally small: it prevents Hermes gateway pickers from rendering
+``ClawRouter (0 models)`` while avoiding a stale copy of the complete catalog.
+"""
+
+from __future__ import annotations
+
+CHAT_MODELS = (
+    "blockrun/auto",
+    "auto",
+    "free",
+    "eco",
+    "premium",
+    "openai/gpt-5.5",
+    "anthropic/claude-opus-4.7",
+    "google/gemini-2.5-pro",
+    "moonshot/kimi-k2.6",
+    "deepseek/deepseek-v4-flash",
+    "minimax/minimax-m2.7",
+)
+
+
+def chat_models() -> list[str]:
+    """Return a mutable copy of the curated chat model catalog."""
+    return list(CHAT_MODELS)

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -43,10 +43,15 @@ def _read_base_url() -> str:
 
 _STATIC_FALLBACKS = (
     "blockrun/auto",
-    "gpt-4o-mini",
-    "claude-3-5-haiku-latest",
-    "grok-2-mini",
-    "deepseek-chat",
+    "auto",
+    "free",
+    "eco",
+    "premium",
+    "openai/gpt-5.5",
+    "anthropic/claude-opus-4.7",
+    "google/gemini-2.5-pro",
+    "moonshot/kimi-k2.6",
+    "deepseek/deepseek-v4-flash",
 )
 
 
@@ -77,7 +82,7 @@ clawrouter = ClawRouterProfile(
     display_name="ClawRouter",
     description="ClawRouter — 55+ models, x402 USDC micropayments (Base + Solana), smart routing",
     signup_url="https://blockrun.ai",
-    env_vars=(),
+    env_vars=("CLAWROUTER_API_KEY",),
     base_url=_read_base_url(),
     models_url=f"{_read_base_url()}/models",
     auth_type="api_key",

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -26,6 +26,7 @@ def test_provider_init_template_calls_register_provider():
     assert "register_provider" in text
     assert "ClawRouterProfile" in text
     assert "base_url" in text
+    assert "CLAWROUTER_API_KEY" in text
 
 
 def test_materialize_writes_correct_filenames(tmp_path, monkeypatch):
@@ -43,6 +44,27 @@ def test_materialize_writes_correct_filenames(tmp_path, monkeypatch):
     assert (target / "__init__.py").is_file()
     assert "register_provider" in (target / "__init__.py").read_text()
     assert "kind: model-provider" in (target / "plugin.yaml").read_text()
+
+
+def test_install_hermes_compat_writes_provider_env_and_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    import importlib
+    import yaml
+    import clawrouter_hermes.cli as cli_module
+    importlib.reload(cli_module)
+
+    cli_module.install_hermes_compat(force_provider=True, set_default=True)
+
+    hermes_home = tmp_path / ".hermes"
+    assert (hermes_home / "plugins" / "model-providers" / "clawrouter" / "__init__.py").is_file()
+    assert "CLAWROUTER_API_KEY=clawrouter-local" in (hermes_home / ".env").read_text()
+
+    config = yaml.safe_load((hermes_home / "config.yaml").read_text())
+    assert config["model"]["provider"] == "clawrouter"
+    assert config["model"]["default"] == "blockrun/auto"
+    assert config["providers"]["clawrouter"]["key_env"] == "CLAWROUTER_API_KEY"
+    assert "blockrun/auto" in config["providers"]["clawrouter"]["models"]
 
 
 def test_hermes_home_env_var_respected(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Add a `hermes-clawrouter` console script so setup works even when Hermes has not loaded plugin CLI commands yet.
- Make setup materialize the provider plugin, seed `CLAWROUTER_API_KEY`, and register ClawRouter in Hermes config for provider/model picker discovery.
- Fix the Hermes plugin entry point to load the plugin module and add compatibility hints for provider registration and starter model picker entries.

## Testing
- `python3 -m pytest`

## Notes
- This intentionally includes only a starter chat model list so `/model` does not show ClawRouter as empty. A complete BlockRun catalog sync should be handled separately.