### PR TITLE
docs: note Python 3.10+ requirement in Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Wraps the existing [ClawRouter](https://github.com/BlockRunAI/ClawRouter) TypeSc
 
 ## Install
 
+Requires Python 3.10+.
+
 ```bash
 pip install hermes-plugin-clawrouter
 hermes plugins enable clawrouter


### PR DESCRIPTION
## Summary
- Add a `Requires Python 3.10+` line to the README **Install** section so it matches `pyproject.toml`'s `requires-python = ">=3.10"`.

## Why
macOS ships Python 3.9 by default. Following the README on a stock system hits:

```
ERROR: Package 'hermes-plugin-clawrouter' requires a different Python: 3.9.6 not in '>=3.10'
```

Surfacing the requirement in the README prevents the silent failure.

## Related (not in this PR)
While verifying the install flow I also noticed `pip install hermes-plugin-clawrouter` itself fails with `No matching distribution found` — 0.1.0 does not appear to be published to PyPI yet. Installing from source (`pip install git+...`) works end-to-end (`setup` correctly writes the provider plugin dir, `.env`, and `config.yaml` exactly as the README describes). Flagging in case it's an oversight.

## Test plan
- [x] Markdown renders correctly in GitHub preview