### PR TITLE
chore: lower requires-python to >=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "MIT" }
 authors = [
     { name = "BlockRun" }
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 keywords = ["hermes", "hermes-agent", "clawrouter", "x402", "llm-router", "blockrun"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
Lower `requires-python` from `>=3.10` to `>=3.9` since no Python 3.10+ features are actually used.

## Evidence
grep over `src/clawrouter_hermes/` — zero hits for any 3.10+ runtime feature:
- no `match` statements
- no runtime union syntax (`isinstance(x, A | B)`)
- no `dataclass(slots=True)`
- no `itertools.pairwise`
- no `typing.ParamSpec` / `TypeAlias` / `Self`
- no 3.11+ stdlib (`tomllib`, `except*`)

All type annotations are stringified by `from __future__ import annotations` at the top of every module, so `list[str] | None` and `dict[str, Any]` don't need to evaluate at runtime — 3.7+ semantics are enough.

Direct deps (`httpx>=0.27`, `bip_utils>=2.9`, `PyYAML>=6.0`) all advertise 3.9 support.

## Why this matters
macOS ships Python 3.9 by default. The current `>=3.10` declaration causes:

```
ERROR: Package 'hermes-plugin-clawrouter' requires a different Python: 3.9.6 not in '>=3.10'
```

…on stock systems, even though the code itself would run fine.

## Caveat
I have not run the full test suite on 3.9 — happy to defer to your CI matrix if you'd rather verify before merging. If you'd prefer to keep the 3.10 floor for team-baseline reasons, see #3 which just surfaces the requirement in the README.

## Test plan
- [ ] `python3.9 -m venv .venv && .venv/bin/pip install -e ".[dev]" && .venv/bin/pytest` in maintainer CI