### PR TITLE
Start ClawRouter proxy for chat provider use

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ hermes-clawrouter doctor
 
 `setup` writes the model-provider plugin to `~/.hermes/plugins/model-providers/clawrouter/`, seeds `CLAWROUTER_API_KEY=clawrouter-local` in `~/.hermes/.env`, and registers ClawRouter in `~/.hermes/config.yaml` so Hermes' `/model` picker can show the provider and curated BlockRun chat models.
 
+`CLAWROUTER_API_KEY` is intentionally a non-secret placeholder. ClawRouter payments use the local wallet/proxy, but Hermes hides API-key-style providers from `/model` unless the configured key env var exists.
+
 `hermes-clawrouter` is provided because some Hermes releases do not add plugin-defined top-level CLI commands before the plugin is enabled. Once the plugin is loaded, `hermes clawrouter <setup|wallet|doctor|route|stats>` may also be available.
 
 ## Usage

--- a/src/clawrouter_hermes/__init__.py
+++ b/src/clawrouter_hermes/__init__.py
@@ -34,6 +34,7 @@ def register(ctx) -> None:
     """Wire all surfaces into the Hermes plugin context."""
     _install_compat()
     _register_tools(ctx)
+    _register_hooks(ctx)
     _register_slash_command(ctx)
     _register_cli(ctx)
     _register_skill(ctx)
@@ -83,6 +84,33 @@ def _register_tools(ctx) -> None:
         description="Web search via ClawRouter Exa (x402-billed)",
         emoji="🔎",
     )
+
+
+def _register_hooks(ctx) -> None:
+    ctx.register_hook("pre_llm_call", _ensure_proxy_for_chat)
+
+
+def _ensure_proxy_for_chat(**kwargs) -> None:
+    """Start the local proxy before Hermes calls the ClawRouter provider."""
+    provider = str(
+        kwargs.get("provider")
+        or kwargs.get("provider_id")
+        or kwargs.get("runtime_provider")
+        or ""
+    ).lower()
+    base_url = str(kwargs.get("base_url") or kwargs.get("api_base") or "").lower()
+    model = str(kwargs.get("model") or "").lower()
+
+    if not (
+        provider in {"clawrouter", "blockrun", "claw"}
+        or "127.0.0.1:8402" in base_url
+        or model.startswith("blockrun/")
+    ):
+        return
+
+    status = proxy_supervisor.ensure_running()
+    if not status.reachable:
+        logger.warning("clawrouter: proxy unavailable before LLM call: %s", status.error)
 
 
 def _register_slash_command(ctx) -> None:

--- a/src/clawrouter_hermes/cli.py
+++ b/src/clawrouter_hermes/cli.py
@@ -191,7 +191,12 @@ def _materialize_provider_plugin(*, force: bool) -> None:
 
 
 def _ensure_local_api_key() -> None:
-    """Seed a harmless local bearer so Hermes treats ClawRouter as configured."""
+    """Seed a harmless local bearer so Hermes lists ClawRouter in /model.
+
+    ClawRouter itself does not use this for payment or wallet auth. Hermes hides
+    API-key-style providers from its model picker unless their key env var is
+    present, so this non-secret placeholder is only a discovery shim.
+    """
     os.environ.setdefault("CLAWROUTER_API_KEY", "clawrouter-local")
     path = _env_file()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -256,7 +261,6 @@ def _configure_hermes_provider(*, set_default_force: bool = False) -> bool:
         "key_env": "CLAWROUTER_API_KEY",
         "transport": "openai_chat",
         "default_model": "blockrun/auto",
-        "discover_models": False,
         "models": models.chat_models(),
     }
     current = providers.get("clawrouter")
@@ -264,6 +268,9 @@ def _configure_hermes_provider(*, set_default_force: bool = False) -> bool:
         providers["clawrouter"] = desired
         changed = True
     else:
+        if "discover_models" in current:
+            current.pop("discover_models", None)
+            changed = True
         for key, value in desired.items():
             if current.get(key) != value:
                 current[key] = value

--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -1,24 +1,34 @@
-"""Starter ClawRouter chat model catalog for Hermes pickers.
+"""Featured ClawRouter chat model catalog for Hermes pickers.
 
 The full BlockRun catalog is maintained by the ClawRouter service. This list is
-intentionally small: it prevents Hermes gateway pickers from rendering
-``ClawRouter (0 models)`` while avoiding a stale copy of the complete catalog.
+intentionally curated for Telegram/gateway pickers: it prevents Hermes from
+rendering ``ClawRouter (0 models)`` without flooding small inline keyboards.
 """
 
 from __future__ import annotations
 
 CHAT_MODELS = (
     "blockrun/auto",
+    "blockrun/free",
+    "blockrun/eco",
+    "blockrun/premium",
     "auto",
     "free",
     "eco",
     "premium",
-    "openai/gpt-5.5",
+    "openai/gpt-5.4",
+    "openai/gpt-5-mini",
     "anthropic/claude-opus-4.7",
+    "anthropic/claude-sonnet-4.6",
     "google/gemini-2.5-pro",
+    "google/gemini-2.5-flash",
     "moonshot/kimi-k2.6",
-    "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-chat",
+    "zai/glm-5.1",
+    "xai/grok-4-1-fast-reasoning",
+    "xai/grok-code-fast-1",
     "minimax/minimax-m2.7",
+    "nvidia/gpt-oss-120b",
 )
 
 

--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -16,6 +16,7 @@ CHAT_MODELS = (
     "free",
     "eco",
     "premium",
+    "openai/gpt-5.5",
     "openai/gpt-5.4",
     "openai/gpt-5-mini",
     "anthropic/claude-opus-4.7",

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -41,18 +41,31 @@ def _read_base_url() -> str:
     return _DEFAULT_BASE_URL
 
 
+# Keep in sync with clawrouter_hermes/models.py::CHAT_MODELS. This template is
+# materialized verbatim (no substitution), so the two lists are hand-maintained
+# duplicates; tests/test_provider_template.py asserts they match.
 _STATIC_FALLBACKS = (
     "blockrun/auto",
+    "blockrun/free",
+    "blockrun/eco",
+    "blockrun/premium",
     "auto",
     "free",
     "eco",
     "premium",
-    "openai/gpt-5.5",
+    "openai/gpt-5.4",
+    "openai/gpt-5-mini",
     "anthropic/claude-opus-4.7",
+    "anthropic/claude-sonnet-4.6",
     "google/gemini-2.5-pro",
+    "google/gemini-2.5-flash",
     "moonshot/kimi-k2.6",
-    "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-chat",
+    "zai/glm-5.1",
+    "xai/grok-4-1-fast-reasoning",
+    "xai/grok-code-fast-1",
     "minimax/minimax-m2.7",
+    "nvidia/gpt-oss-120b",
 )
 
 

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -2,11 +2,25 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.resources as resources
 
 
 def _template_dir():
     return resources.files("clawrouter_hermes").joinpath("provider_template")
+
+
+def _template_static_fallbacks() -> tuple[str, ...]:
+    """Extract the _STATIC_FALLBACKS tuple from the (un-importable) template."""
+    source = _template_dir().joinpath("init.py.tmpl").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "_STATIC_FALLBACKS"
+            for t in node.targets
+        ):
+            return tuple(ast.literal_eval(node.value))
+    raise AssertionError("_STATIC_FALLBACKS not found in init.py.tmpl")
 
 
 def test_template_files_present():
@@ -27,6 +41,16 @@ def test_provider_init_template_calls_register_provider():
     assert "ClawRouterProfile" in text
     assert "base_url" in text
     assert "CLAWROUTER_API_KEY" in text
+
+
+def test_template_fallbacks_match_chat_models():
+    """The materialized provider's fallback_models must stay in sync with the
+    curated picker catalog in models.py. The template is copied verbatim (no
+    substitution), so the two lists are hand-maintained duplicates and drift
+    silently if only one is edited."""
+    from clawrouter_hermes import models
+
+    assert _template_static_fallbacks() == tuple(models.chat_models())
 
 
 def test_materialize_writes_correct_filenames(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Add a `pre_llm_call` hook so using provider `clawrouter` in normal chat starts the local `npx @blockrun/clawrouter` proxy before Hermes calls `127.0.0.1:8402`.
- Expand the Hermes picker list from a minimal starter set to a curated featured list that includes `blockrun/auto`, `blockrun/free`, `blockrun/eco`, and `blockrun/premium`.
- Document that `CLAWROUTER_API_KEY=clawrouter-local` is a non-secret Hermes discovery shim, not ClawRouter wallet/payment auth.

## Testing
- Installed the local package in a Hermes gateway testbed.
- Verified plugin loads from the real package entry point and `/clawrouter` registers.
- Verified `/model` picker data shows ClawRouter with 21 models.
- Verified `hermes --provider clawrouter -m blockrun/auto -z ...` succeeds after the hook starts the proxy.
- `python3 -m pytest` passes: 33 passed, 3 skipped.