### PR TITLE
Fix qwen3-coder model ID, add 1M context, pre-install & auto-update proxy

### DIFF
--- a/src/clawrouter_hermes/cli.py
+++ b/src/clawrouter_hermes/cli.py
@@ -210,22 +210,18 @@ def _ensure_local_api_key() -> None:
 
 
 def _install_clawrouter_proxy() -> None:
-    """Pre-install the @blockrun/clawrouter proxy so /model is instant."""
+    """Ensure @blockrun/clawrouter proxy is installed and up to date."""
     npm_dir = Path.home() / ".openclaw" / "npm"
-    package_json = npm_dir / "package.json"
-    installed_marker = npm_dir / "node_modules" / "@blockrun" / "clawrouter"
-    if installed_marker.is_dir() and package_json.is_file():
-        print("✓ ClawRouter proxy already installed.")
-        return
-
     npm_dir.mkdir(parents=True, exist_ok=True)
+
+    package_json = npm_dir / "package.json"
     if not package_json.is_file():
         package_json.write_text(json.dumps({"private": True}), encoding="utf-8")
 
-    print("Installing ClawRouter proxy…", end=" ", flush=True)
+    print("Updating ClawRouter proxy…", end=" ", flush=True)
     try:
         result = subprocess.run(
-            ["npm", "install", "@blockrun/clawrouter"],
+            ["npm", "install", "@blockrun/clawrouter@latest"],
             cwd=str(npm_dir),
             capture_output=True,
             text=True,

--- a/src/clawrouter_hermes/cli.py
+++ b/src/clawrouter_hermes/cli.py
@@ -276,6 +276,14 @@ def _configure_hermes_provider(*, set_default_force: bool = False) -> bool:
                 current[key] = value
                 changed = True
 
+    model_cfg = config.setdefault("model", {})
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+        config["model"] = model_cfg
+    if model_cfg.get("context_length") != 1_000_000:
+        model_cfg["context_length"] = 1_000_000
+        changed = True
+
     if changed or not path.exists():
         path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
     return changed

--- a/src/clawrouter_hermes/cli.py
+++ b/src/clawrouter_hermes/cli.py
@@ -147,6 +147,7 @@ def _setup(args: argparse.Namespace) -> None:
         print("  Install Node.js 18+ from https://nodejs.org and re-run setup.")
     else:
         print("✓ Node / npx detected.")
+        _install_clawrouter_proxy()
 
     if wallet.MNEMONIC_FILE.is_file():
         try:
@@ -206,6 +207,38 @@ def _ensure_local_api_key() -> None:
     prefix = existing.rstrip()
     suffix = "\n" if prefix else ""
     path.write_text(f"{prefix}{suffix}CLAWROUTER_API_KEY=clawrouter-local\n", encoding="utf-8")
+
+
+def _install_clawrouter_proxy() -> None:
+    """Pre-install the @blockrun/clawrouter proxy so /model is instant."""
+    npm_dir = Path.home() / ".openclaw" / "npm"
+    package_json = npm_dir / "package.json"
+    installed_marker = npm_dir / "node_modules" / "@blockrun" / "clawrouter"
+    if installed_marker.is_dir() and package_json.is_file():
+        print("✓ ClawRouter proxy already installed.")
+        return
+
+    npm_dir.mkdir(parents=True, exist_ok=True)
+    if not package_json.is_file():
+        package_json.write_text(json.dumps({"private": True}), encoding="utf-8")
+
+    print("Installing ClawRouter proxy…", end=" ", flush=True)
+    try:
+        result = subprocess.run(
+            ["npm", "install", "@blockrun/clawrouter"],
+            cwd=str(npm_dir),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode == 0:
+            print("done.")
+        else:
+            print(f"\n✗ npm install failed: {result.stderr.strip()[:200]}")
+            print("  The proxy will be installed on first use via npx.")
+    except Exception as exc:
+        print(f"\n✗ npm install failed: {exc}")
+        print("  The proxy will be installed on first use via npx.")
 
 
 def _configure_hermes_provider(*, set_default_force: bool = False) -> bool:

--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -28,14 +28,14 @@ CHAT_MODELS = (
     "minimax/minimax-m2.7",
     "nvidia/gpt-oss-120b",
     "free/glm-4.7",
-    "free/qwen3-coder-480b",
+    "nvidia/qwen3-coder-480b",
 )
 
 FREE_MODELS = frozenset({
     "blockrun/free",
     "nvidia/gpt-oss-120b",
     "free/glm-4.7",
-    "free/qwen3-coder-480b",
+    "nvidia/qwen3-coder-480b",
 })
 
 

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -65,7 +65,7 @@ _STATIC_FALLBACKS = (
     "minimax/minimax-m2.7",
     "nvidia/gpt-oss-120b",
     "free/glm-4.7",
-    "free/qwen3-coder-480b",
+    "nvidia/qwen3-coder-480b",
 )
 
 


### PR DESCRIPTION
Follow-up to the Opus 4.8 picker PR (#7).

- Use `nvidia/qwen3-coder-480b` instead of `free/qwen3-coder-480b` (matches BlockRun API ID)
- Write `context_length: 1000000` in config during setup so Opus 4.8 shows 1M instead of 200K
- Pre-install `@blockrun/clawrouter` proxy during `hermes-clawrouter setup` — no first-use delay on `/model`
- Always install `@latest` to keep proxy in sync with plugin on `setup --force`