### PR TITLE
Fix compression: empty aux model + lower threshold to 0.20

### DIFF
--- a/src/clawrouter_hermes/cli.py
+++ b/src/clawrouter_hermes/cli.py
@@ -318,6 +318,14 @@ def _configure_hermes_provider(*, set_default_force: bool = False) -> bool:
         model_cfg["context_length"] = 1_000_000
         changed = True
 
+    compression_cfg = config.setdefault("compression", {})
+    if not isinstance(compression_cfg, dict):
+        compression_cfg = {}
+        config["compression"] = compression_cfg
+    if compression_cfg.get("threshold") != 0.20:
+        compression_cfg["threshold"] = 0.20
+        changed = True
+
     if changed or not path.exists():
         path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
     return changed

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -62,7 +62,7 @@ _STATIC_FALLBACKS = (
     "zai/glm-5.1",
     "xai/grok-4-1-fast-reasoning",
     "xai/grok-code-fast-1",
-    "minimax/minimax-m2.7",
+    "minimax/minimax-m3",
     "nvidia/gpt-oss-120b",
     "free/glm-4.7",
     "nvidia/qwen3-coder-480b",
@@ -101,7 +101,7 @@ clawrouter = ClawRouterProfile(
     models_url=f"{_read_base_url()}/models",
     auth_type="api_key",
     fallback_models=_STATIC_FALLBACKS,
-    default_aux_model="blockrun/auto",
+    default_aux_model="",
     default_headers={
         "X-Hermes-Plugin": "clawrouter",
     },


### PR DESCRIPTION
Eliminates the constant compression warnings in chat.

- Set `default_aux_model` to empty string — Hermes uses the main model for compression instead of `blockrun/auto`
- Lower `compression.threshold` to 0.20 in config so it doesn't nag when models.dev context data is stale
- Sync provider template with models.py (MiniMax M3)