### PR TITLE
fix(installer): preserve recovery paths; refresh SKILL.md free models

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,14 @@ fi
 
 PLUGIN_NAME="${HERMES_CLAWROUTER_PLUGIN_NAME:-clawrouter}"
 BROKEN_HERMES_TARGET=""
+# find_hermes_python() runs inside a command substitution (subshell), so it
+# cannot export a broken-launcher path back to main() via a variable. Stash it
+# in a temp file instead and read it back in the parent shell.
+BROKEN_HERMES_TARGET_FILE="$(mktemp 2>/dev/null || true)"
+cleanup() {
+  [[ -n "$BROKEN_HERMES_TARGET_FILE" && -f "$BROKEN_HERMES_TARGET_FILE" ]] && rm -f "$BROKEN_HERMES_TARGET_FILE"
+}
+trap cleanup EXIT
 
 log() { printf '%s\n' "$*"; }
 warn() { printf 'WARN: %s\n' "$*" >&2; }
@@ -246,6 +254,9 @@ find_hermes_python() {
         fi
       else
         BROKEN_HERMES_TARGET="$target"
+        if [[ -n "$BROKEN_HERMES_TARGET_FILE" ]]; then
+          printf '%s\n' "$target" > "$BROKEN_HERMES_TARGET_FILE"
+        fi
       fi
     fi
 
@@ -349,11 +360,17 @@ install_into_venv() {
   local py="$1"
   log "Installing $PKG_SPEC into Hermes environment: $py"
   ensure_venv_pip "$py"
-  "$py" -m pip install --upgrade pip wheel >/dev/null
-  "$py" -m pip install --upgrade "$PKG_SPEC"
+  "$py" -m pip install --upgrade pip wheel >/dev/null || true
+  if ! "$py" -m pip install --upgrade "$PKG_SPEC"; then
+    warn "pip failed to install $PKG_SPEC into $py."
+    return 1
+  fi
   ensure_node_tooling || warn "Node/npm/npx not available; setup will still run, but ClawRouter proxy install may be deferred or fail."
   enable_plugin "$py"
-  run_clawrouter_cli "$py" setup --force
+  if ! run_clawrouter_cli "$py" setup --force; then
+    warn "ClawRouter setup failed under $py."
+    return 1
+  fi
   log "Running doctor (warnings are OK if the wallet is not funded yet)..."
   run_clawrouter_cli "$py" doctor || true
 }
@@ -398,9 +415,11 @@ main() {
 
   local hermes_py
   if hermes_py="$(find_hermes_python)"; then
-    install_into_venv "$hermes_py"
-    log "Done. Restart Hermes, then choose blockrun/auto in /model."
-    return 0
+    if install_into_venv "$hermes_py"; then
+      log "Done. Restart Hermes, then choose blockrun/auto in /model."
+      return 0
+    fi
+    warn "Installing into Hermes' venv did not complete; trying pipx fallback..."
   fi
 
   repair_broken_hermes_launcher
@@ -408,6 +427,12 @@ main() {
   if install_with_pipx; then
     log "Done. Restart Hermes, then choose blockrun/auto in /model."
     return 0
+  fi
+
+  # find_hermes_python ran in a subshell, so recover the broken-launcher path
+  # it may have stashed for us.
+  if [[ -z "$BROKEN_HERMES_TARGET" && -n "$BROKEN_HERMES_TARGET_FILE" && -s "$BROKEN_HERMES_TARGET_FILE" ]]; then
+    IFS= read -r BROKEN_HERMES_TARGET < "$BROKEN_HERMES_TARGET_FILE" || true
   fi
 
   if [[ -n "$BROKEN_HERMES_TARGET" ]]; then

--- a/src/clawrouter_hermes/skills/clawrouter/SKILL.md
+++ b/src/clawrouter_hermes/skills/clawrouter/SKILL.md
@@ -158,7 +158,7 @@ Rules handle ~80% of requests in <1ms. Only ambiguous queries hit the LLM classi
 
 ## Available Models
 
-55+ models including: gpt-5.5, gpt-5.4, gpt-4o, o3, claude-opus-4.7, claude-opus-4.6, claude-opus-4.5, claude-sonnet-4.6, gemini-3.1-pro, gemini-3.5-flash, deepseek-v4-pro, deepseek-chat, grok-4.3, grok-build-0.1, kimi-k2.6, kimi-k2.5, and 10 free NVIDIA models (gpt-oss-120b [default], gpt-oss-20b, mistral-small-4-119b, deepseek-v4-pro, deepseek-v4-flash, qwen3-next-80b-a3b-thinking, qwen3-coder-480b, glm-4.7, llama-4-maverick, nemotron-3-nano-omni-30b-a3b-reasoning [vision]).
+55+ models including: gpt-5.5, gpt-5.4, gpt-5-mini, claude-opus-4.8, claude-opus-4.7, claude-sonnet-4.6, gemini-3.1-pro, gemini-3.5-flash, deepseek-v4-pro, deepseek-chat, glm-5.1, grok-4.3, grok-build-0.1, kimi-k2.6, minimax-m3, and the curated free models (gpt-oss-120b, gpt-oss-20b, mistral-large-3-675b, qwen3.5-122b-a10b, llama-4-maverick, qwen3-coder-480b, nemotron-3-nano-omni-30b-a3b-reasoning [vision]).
 
 ## Built-in Agent Tools
 


### PR DESCRIPTION
Follow-up to #15 — fixes three review findings.

## Findings addressed
1. **Broken-launcher warning never fired.** `find_hermes_python` runs inside a command-substitution subshell (`hermes_py="$(find_hermes_python)"`), so its `BROKEN_HERMES_TARGET` assignment was lost and main()'s "launcher points to a missing file" warning was always skipped. Now stashed via a temp file (cleaned up on EXIT) and read back in the parent shell.
2. **Venv-install failure aborted the whole installer.** `install_into_venv` ran unconditionally under `set -e`, so a transient `pip install` failure killed the script with a raw traceback before the pipx fallback or the manual-recovery help block. It now returns non-zero on pip/setup failure and main() falls through to the pipx path + guidance.
3. **Stale model list in SKILL.md.** The `Available Models` prose still advertised removed models (glm-4.7, mistral-small-4-119b, deepseek-v4-flash, qwen3-next…). Refreshed to the curated catalog.

## Testing
- `bash -n scripts/install.sh` ✓
- `shellcheck scripts/install.sh` — clean ✓
- `python -m pytest` — 59 passed, 3 skipped ✓