### PR TITLE
fix(models): add Claude Sonnet 5 to picker

### DIFF
--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -14,6 +14,7 @@ CHAT_MODELS = (
     "blockrun/free",
     "blockrun/eco",
     "blockrun/premium",
+    "blockrun/anthropic/claude-sonnet-5",
     "blockrun/anthropic/claude-sonnet-4.6",
     "blockrun/anthropic/claude-opus-4.8",
     "blockrun/anthropic/claude-opus-4.7",

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -49,6 +49,7 @@ _STATIC_FALLBACKS = (
     "blockrun/free",
     "blockrun/eco",
     "blockrun/premium",
+    "blockrun/anthropic/claude-sonnet-5",
     "blockrun/anthropic/claude-sonnet-4.6",
     "blockrun/anthropic/claude-opus-4.8",
     "blockrun/anthropic/claude-opus-4.7",

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -81,6 +81,7 @@ def test_curated_picker_catalog_orders_featured_models():
     # Relative order mirrors ClawRouter's top-models.json: sonnet before opus,
     # deepseek/moonshot before xai, free block before the zai/glm block.
     featured_order = [
+        "blockrun/anthropic/claude-sonnet-5",
         "blockrun/anthropic/claude-sonnet-4.6",
         "blockrun/anthropic/claude-opus-4.8",
         "blockrun/openai/gpt-5.5",


### PR DESCRIPTION
## Summary

- Add `blockrun/anthropic/claude-sonnet-5` to the curated ClawRouter picker catalog.
- Keep the provider template fallback list in sync.
- Add Sonnet 5 to the ordering regression test, before Sonnet 4.6 to match ClawRouter top-models order.

## Testing

- `python3.11 -m py_compile src/clawrouter_hermes/models.py tests/test_provider_template.py`
- Parsed `src/clawrouter_hermes/provider_template/init.py.tmpl` with `ast.parse`
- Ran dependency-free catalog assertions for:
  - provider template fallbacks match `CHAT_MODELS`
  - Sonnet 5/Sonnet 4.6/Opus ordering
  - router aliases remain first
  - ZAI/GLM tail remains ordered
  - retired `blockrun/free/qwen3-coder-480b` remains absent

Full pytest was not runnable locally because isolated dependency install failed due PyPI DNS/build dependency resolution:

```text
Failed to resolve pypi.org
No matching distribution found for Cython>=3.0 while installing PyYAML build dependencies under Python 3.13
```
