### PR TITLE
Fix stale hermes-clawrouter launcher after updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ lives:
 ```bash
 ~/.hermes/hermes-agent/venv/bin/python -m pip install -U hermes-plugin-clawrouter
 hermes plugins enable clawrouter
-hermes-clawrouter setup
-hermes-clawrouter doctor
+~/.hermes/hermes-agent/venv/bin/hermes-clawrouter setup
+~/.hermes/hermes-agent/venv/bin/hermes-clawrouter doctor
 ```
 
 If `pip install hermes-plugin-clawrouter` shows `externally-managed-environment`,
@@ -41,6 +41,11 @@ ClawRouter installer.
 `CLAWROUTER_API_KEY` is intentionally a non-secret placeholder. ClawRouter payments use the local wallet/proxy, but Hermes hides API-key-style providers from `/model` unless the configured key env var exists.
 
 `hermes-clawrouter` is provided because some Hermes releases do not add plugin-defined top-level CLI commands before the plugin is enabled. Once the plugin is loaded, `hermes clawrouter <setup|wallet|doctor|route|stats>` may also be available.
+
+If `hermes-clawrouter --version` shows an older version after updating, your shell
+may be finding an old `~/.local/bin/hermes-clawrouter` from a previous `pip --user`
+install. Re-run the one-command installer; it refreshes that launcher to delegate
+to Hermes' current venv.
 
 ## Usage
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -292,6 +292,38 @@ run_clawrouter_cli() {
   fi
 }
 
+sync_user_cli_launcher() {
+  local py="$1"
+  local bin_dir cli user_bin launcher backup target
+  bin_dir="$(dirname "$py")"
+  cli="$bin_dir/hermes-clawrouter"
+  [[ -x "$cli" ]] || return 0
+
+  user_bin="$HOME/.local/bin"
+  launcher="$user_bin/hermes-clawrouter"
+  mkdir -p "$user_bin"
+
+  if [[ -L "$launcher" ]]; then
+    target="$(readlink "$launcher" 2>/dev/null || true)"
+    if [[ "$target" != "$cli" ]]; then
+      backup="$launcher.bak.$(date +%Y%m%d%H%M%S)"
+      mv "$launcher" "$backup"
+      warn "Moved old hermes-clawrouter launcher to $backup"
+    fi
+  elif [[ -e "$launcher" ]] && ! grep -Fq "exec \"$cli\"" "$launcher" 2>/dev/null; then
+    backup="$launcher.bak.$(date +%Y%m%d%H%M%S)"
+    mv "$launcher" "$backup"
+    warn "Moved old hermes-clawrouter launcher to $backup"
+  fi
+
+  cat > "$launcher" <<EOF
+#!/usr/bin/env sh
+exec "$cli" "\$@"
+EOF
+  chmod +x "$launcher"
+  log "Updated user launcher: $launcher -> $cli"
+}
+
 enable_plugin_in_config() {
   local py="$1"
   "$py" - "$PLUGIN_NAME" <<'PY'
@@ -365,6 +397,7 @@ install_into_venv() {
     warn "pip failed to install $PKG_SPEC into $py."
     return 1
   fi
+  sync_user_cli_launcher "$py"
   ensure_node_tooling || warn "Node/npm/npx not available; setup will still run, but ClawRouter proxy install may be deferred or fail."
   enable_plugin "$py"
   if ! run_clawrouter_cli "$py" setup --force; then


### PR DESCRIPTION
## Summary
- refresh ~/.local/bin/hermes-clawrouter after installing into Hermes' venv
- back up older launchers before replacing them with a venv-delegating shim
- update manual install docs to call the venv CLI directly

## Verification
- bash -n scripts/install.sh
- python3 -m pytest
- python3 -m pip wheel . -w /tmp/opencode/ClawRouter-Hermes-shim/dist