### PR TITLE
Fix stale hermes-clawrouter launcher after updates (hardened)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ lives:
 ```bash
 ~/.hermes/hermes-agent/venv/bin/python -m pip install -U hermes-plugin-clawrouter
 hermes plugins enable clawrouter
-hermes-clawrouter setup
-hermes-clawrouter doctor
+~/.hermes/hermes-agent/venv/bin/hermes-clawrouter setup
+~/.hermes/hermes-agent/venv/bin/hermes-clawrouter doctor
 ```
 
 If `pip install hermes-plugin-clawrouter` shows `externally-managed-environment`,
@@ -41,6 +41,11 @@ ClawRouter installer.
 `CLAWROUTER_API_KEY` is intentionally a non-secret placeholder. ClawRouter payments use the local wallet/proxy, but Hermes hides API-key-style providers from `/model` unless the configured key env var exists.
 
 `hermes-clawrouter` is provided because some Hermes releases do not add plugin-defined top-level CLI commands before the plugin is enabled. Once the plugin is loaded, `hermes clawrouter <setup|wallet|doctor|route|stats>` may also be available.
+
+If `hermes-clawrouter --version` shows an older version after updating, your shell
+may be finding an old `~/.local/bin/hermes-clawrouter` from a previous `pip --user`
+install. Re-run the one-command installer; it refreshes that launcher to delegate
+to Hermes' current venv.
 
 ## Usage
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -292,6 +292,82 @@ run_clawrouter_cli() {
   fi
 }
 
+# Refresh ~/.local/bin/hermes-clawrouter so a stale launcher from an old
+# `pip install --user` cannot shadow the freshly installed venv CLI. Launcher
+# refresh is best-effort: every failure warns and returns 0 so it can never
+# abort or fail an otherwise successful install.
+sync_user_cli_launcher() {
+  local py="$1"
+  local bin_dir cli esc_cli shim_exec user_bin launcher backup tmp
+  py="$(resolve_path "$py")"
+  bin_dir="$(dirname "$py")"
+  cli="$bin_dir/hermes-clawrouter"
+  [[ -x "$cli" ]] || return 0
+  case "$cli" in
+    /*) ;;
+    *)
+      warn "Refusing to write user launcher for non-absolute CLI path: $cli"
+      return 0
+      ;;
+  esac
+
+  user_bin="$HOME/.local/bin"
+  launcher="$user_bin/hermes-clawrouter"
+  if ! mkdir -p "$user_bin" 2>/dev/null; then
+    warn "Could not create $user_bin; skipping hermes-clawrouter launcher refresh."
+    return 0
+  fi
+
+  # Single-quote for POSIX sh, escaping embedded single quotes.
+  esc_cli="$(printf '%s' "$cli" | sed "s/'/'\\\\''/g")"
+  shim_exec="exec '$esc_cli' \"\$@\""
+
+  if [[ -L "$launcher" ]]; then
+    if [[ "$(resolve_path "$launcher")" == "$(resolve_path "$cli")" ]]; then
+      # Already points at the current CLI (e.g. pipx-managed). Leave it to
+      # its owner. Never write through a symlink: with a same-target link,
+      # `cat >` would overwrite the venv's real console script with a shim
+      # that execs itself forever.
+      return 0
+    fi
+    backup="$launcher.bak.$(date +%Y%m%d%H%M%S).$$"
+    if ! mv "$launcher" "$backup" 2>/dev/null; then
+      warn "Could not move old hermes-clawrouter launcher aside; skipping refresh."
+      return 0
+    fi
+    warn "Moved old hermes-clawrouter launcher to $backup"
+  elif [[ -e "$launcher" && ! -f "$launcher" ]]; then
+    warn "$launcher exists but is not a regular file; skipping launcher refresh."
+    return 0
+  elif [[ -f "$launcher" ]] && ! grep -Fq "$shim_exec" "$launcher" 2>/dev/null; then
+    backup="$launcher.bak.$(date +%Y%m%d%H%M%S).$$"
+    if ! mv "$launcher" "$backup" 2>/dev/null; then
+      warn "Could not move old hermes-clawrouter launcher aside; skipping refresh."
+      return 0
+    fi
+    warn "Moved old hermes-clawrouter launcher to $backup"
+  fi
+
+  # Write to a temp file and rename so the launcher is replaced atomically
+  # and no write ever goes through a pre-existing path.
+  if ! tmp="$(mktemp "$user_bin/.hermes-clawrouter.XXXXXX" 2>/dev/null)"; then
+    warn "Could not create temp file in $user_bin; skipping launcher refresh."
+    return 0
+  fi
+  if ! printf '#!/usr/bin/env sh\n%s\n' "$shim_exec" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    warn "Could not write $launcher; skipping launcher refresh."
+    return 0
+  fi
+  chmod +x "$tmp" 2>/dev/null || true
+  if ! mv -f "$tmp" "$launcher" 2>/dev/null; then
+    rm -f "$tmp"
+    warn "Could not install $launcher; skipping launcher refresh."
+    return 0
+  fi
+  log "Updated user launcher: $launcher -> $cli"
+}
+
 enable_plugin_in_config() {
   local py="$1"
   "$py" - "$PLUGIN_NAME" <<'PY'
@@ -365,6 +441,7 @@ install_into_venv() {
     warn "pip failed to install $PKG_SPEC into $py."
     return 1
   fi
+  sync_user_cli_launcher "$py"
   ensure_node_tooling || warn "Node/npm/npx not available; setup will still run, but ClawRouter proxy install may be deferred or fail."
   enable_plugin "$py"
   if ! run_clawrouter_cli "$py" setup --force; then
@@ -391,6 +468,7 @@ install_with_pipx() {
   hermes_bin="$pipx_bin/hermes"
   cli="$pipx_bin/hermes-clawrouter"
 
+  sync_user_cli_launcher "$pipx_bin/python"
   enable_plugin "$pipx_bin/python"
 
   ensure_node_tooling || warn "Node/npm/npx not available; setup will still run, but ClawRouter proxy install may be deferred or fail."


### PR DESCRIPTION
## Summary

Supersedes #22 — credit to @0xCheetah1 for identifying the stale-launcher problem and the delegating-shim approach. This PR keeps that idea and the README changes, with a hardened `sync_user_cli_launcher`:

- **Never writes through a symlink.** In #22, a launcher symlinked to the venv CLI (exactly what `pipx inject --include-apps` creates) skipped the backup and then `cat >` wrote *through* the link, overwriting the real console script with a shim that execs itself — infinite exec loop, CLI destroyed with no backup, installer hung at `setup --force`. Same-target symlinks are now detected via `resolve_path` and left alone.
- **Atomic replace** via `mktemp` in the target dir + `mv -f` (kills the TOCTOU check-then-write window).
- **Shell-safe shim generation**: the CLI path is single-quote-escaped for POSIX sh, so quotes/`$`/backticks in $HOME or `HERMES_PYTHON` can't break the shim or execute at shim runtime.
- **Absolute paths only**: the venv python is resolved first; a relative CLI path is refused rather than baked into the shim.
- **Best-effort**: every failure path warns and returns 0 — no false "Updated user launcher" logs, no aborting an otherwise successful install.
- **Unique backups** (timestamp + pid), FIFO/directory guard, no backup churn on reruns.
- **pipx path covered too**: `install_with_pipx` now also refreshes the launcher, so the README's "re-run the installer" claim holds on both install paths.

## Verification

- `bash -n scripts/install.sh` and `shellcheck -S warning scripts/install.sh` clean
- `python3 -m pytest` — 69 passed, 3 skipped
- Sandboxed functional harness (fake $HOME + fake venv), 17/17 passing, covering: fresh install, stale `pip --user` file (backed up, content preserved), **symlink-to-current-CLI (venv script survives, symlink preserved)**, foreign symlink (replaced, target untouched), rerun idempotency (no backup churn), directory at launcher path (skipped + warn), paths with spaces/single quotes, relative `HERMES_PYTHON`, and `$(...)` metacharacter paths (no command substitution executed).