### PR TITLE
Add Qwen to ClawRouter-Hermes picker catalog

### DIFF
--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -43,6 +43,7 @@ CHAT_MODELS = (
     "blockrun/minimax/minimax-m3",
     "blockrun/minimax/minimax-m2.7",
     "blockrun/moonshot/kimi-k3",
+    "blockrun/qwen/qwen3.7-max",
     "blockrun/deepseek/deepseek-v4-pro",
     "blockrun/deepseek/deepseek-chat",
     "blockrun/deepseek/deepseek-reasoner",

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -78,6 +78,7 @@ _STATIC_FALLBACKS = (
     "blockrun/minimax/minimax-m3",
     "blockrun/minimax/minimax-m2.7",
     "blockrun/moonshot/kimi-k3",
+    "blockrun/qwen/qwen3.7-max",
     "blockrun/deepseek/deepseek-v4-pro",
     "blockrun/deepseek/deepseek-chat",
     "blockrun/deepseek/deepseek-reasoner",

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -95,6 +95,7 @@ def test_curated_picker_catalog_orders_featured_models():
         "blockrun/zai/glm-5.2",
         "blockrun/minimax/minimax-m3",
         "blockrun/moonshot/kimi-k3",
+        "blockrun/qwen/qwen3.7-max",
         "blockrun/deepseek/deepseek-v4-pro",
         "blockrun/free/mistral-large-3-675b",
     ]


### PR DESCRIPTION
## Summary
- add blockrun/qwen/qwen3.7-max to the curated Hermes picker catalog
- keep the materialized provider template in sync
- extend the picker-order regression test

## Verification
- python3 -m pytest
- python3 -m pip wheel . -w /tmp/opencode/ClawRouter-Hermes-shim/dist