### PR TITLE
fix: add Opus 5 to picker catalog

### DIFF
--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -15,6 +15,7 @@ CHAT_MODELS = (
     "blockrun/eco",
     "blockrun/free",
     "blockrun/anthropic/claude-fable-5",
+    "blockrun/anthropic/claude-opus-5",
     "blockrun/anthropic/claude-opus-4.8",
     "blockrun/anthropic/claude-opus-4.7",
     "blockrun/anthropic/claude-sonnet-5",

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -50,6 +50,7 @@ _STATIC_FALLBACKS = (
     "blockrun/eco",
     "blockrun/free",
     "blockrun/anthropic/claude-fable-5",
+    "blockrun/anthropic/claude-opus-5",
     "blockrun/anthropic/claude-opus-4.8",
     "blockrun/anthropic/claude-opus-4.7",
     "blockrun/anthropic/claude-sonnet-5",

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -82,6 +82,7 @@ def test_curated_picker_catalog_orders_featured_models():
     ]
     featured_order = [
         "blockrun/anthropic/claude-fable-5",
+        "blockrun/anthropic/claude-opus-5",
         "blockrun/anthropic/claude-opus-4.8",
         "blockrun/anthropic/claude-sonnet-5",
         "blockrun/anthropic/claude-sonnet-4.6",


### PR DESCRIPTION
## Summary

Add `blockrun/anthropic/claude-opus-5` to the curated ClawRouter model picker catalog.

The model is now available through ClawRouter, but Hermes' curated picker still jumped from Fable 5 to Opus 4.8, so Opus 5 did not appear in the ClawRouter provider list.

## Changes

- Add `blockrun/anthropic/claude-opus-5` to `CHAT_MODELS` after Fable 5.
- Add the same entry to the materialized provider template fallback list.
- Update the picker ordering test.

## Verification

- `python3 -m pytest` -> `69 passed, 3 skipped`
- Testbed hotpatch verified:
  - active package catalog contains `blockrun/anthropic/claude-opus-5`
  - materialized provider contains `blockrun/anthropic/claude-opus-5`
  - `/home/Blockrun/.hermes/config.yaml` contains `blockrun/anthropic/claude-opus-5`
  - `hermes-clawrouter doctor` passes
  - `hermes-gateway.service` restarted and active
