### PR TITLE
test(models): drop the post-top-models exemptions, ClawRouter #290 landed them

### DIFF
--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -202,13 +202,9 @@ def test_curated_picker_catalog_orders_featured_models():
 #: yet picked up upstream, so they are exempt from the mirror check until
 #: ClawRouter ships them. Drop each one from here the moment it lands in
 #: top-models.json — a stale entry silences the guard for a real drift.
-POST_TOP_MODELS_ADDITIONS: frozenset = frozenset({
-    # Added 2026-08-31 sync.
-    "blockrun/google/gemini-3.6-flash",
-    "blockrun/google/gemini-3.5-flash-lite",
-    "blockrun/tencent/hy3",
-    "blockrun/xiaomi/mimo-v2.5-pro",
-})
+#: Empty since 2026-08-31: ClawRouter #290 landed all four, so the picker
+#: mirrors top-models.json entry for entry again.
+POST_TOP_MODELS_ADDITIONS: frozenset = frozenset()
 
 #: Entries whose picker placement deliberately diverges from top-models.json
 #: order; membership is still enforced. Empty since 2026-08-31 — its only


### PR DESCRIPTION
## Summary

[ClawRouter #290](https://github.com/BlockRunAI/ClawRouter/pull/290) added `gemini-3.6-flash`, `gemini-3.5-flash-lite`, `tencent/hy3` and `xiaomi/mimo-v2.5-pro` to `top-models.json`, which is what `POST_TOP_MODELS_ADDITIONS` existed to work around. Emptying it puts all four back under `test_curated_picker_catalog_mirrors_clawrouter_top_models`.

An exemption that outlives its reason is worse than no exemption: it silences the guard for real drift on exactly those ids.

All 55 curated entries are now checked with no carve-outs — `POST_TOP_MODELS_ADDITIONS` and `CURATED_PLACEMENT_OVERRIDES` are both empty, and `models.py` mirrors `top-models.json` entry for entry and in order.

## Tests

`python3 -m pytest` with a sibling ClawRouter checkout: **83 passed, 3 skipped**.

Note the guard `pytest.skip`s without that sibling checkout, so CI here will report 82 passed / 4 skipped — it cannot exercise this change. Verified locally against ClawRouter `main` at 7cf2547.