### PR TITLE
ci: run pytest, with ClawRouter checked out beside the repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+# The Python test suite. Until 2026-08-31 this repo had no test workflow at
+# all — the only CI was the brand-numbers marker check — so nothing but a
+# developer's local run ever exercised tests/.
+#
+# The sibling checkout is the point. test_curated_picker_catalog_mirrors_
+# clawrouter_top_models validates the curated catalog against ClawRouter's
+# top-models.json, and it pytest.skips when that file is absent. On a bare
+# runner it therefore skipped every time, and the catalog drifted unnoticed:
+# by the 2026-08-31 sync the guard was red on main and on the open PR
+# simultaneously, with green checks on both. Checking ClawRouter out beside
+# this repo is what makes the guard mean something in CI.
+#
+# CLAWROUTER_SIBLING_REQUIRED turns the skip into a failure, so a rename or a
+# broken checkout path fails loudly here instead of quietly reverting CI to
+# the state described above.
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ClawRouter-Hermes
+
+      # tests/ resolves the sibling as <repo root>/../ClawRouter, so the two
+      # checkouts must sit side by side under the workspace root.
+      - uses: actions/checkout@v4
+        with:
+          repository: BlockRunAI/ClawRouter
+          path: ClawRouter
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install
+        working-directory: ClawRouter-Hermes
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[dev]"
+
+      - name: pytest
+        working-directory: ClawRouter-Hermes
+        env:
+          CLAWROUTER_SIBLING_REQUIRED: "1"
+        run: python -m pytest -q -rs

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import importlib.resources as resources
 import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -226,6 +227,14 @@ def test_curated_picker_catalog_mirrors_clawrouter_top_models():
         _repo_root().parent / "ClawRouter" / "src" / "top-models.json"
     )
     if not top_models_path.is_file():
+        # CI sets this after checking ClawRouter out beside this repo. Without
+        # it a broken checkout path would silently reduce CI to the state that
+        # let the catalog drift in the first place: a green skip.
+        if os.environ.get("CLAWROUTER_SIBLING_REQUIRED"):
+            raise AssertionError(
+                f"CLAWROUTER_SIBLING_REQUIRED is set but {top_models_path} is "
+                "missing — check the sibling checkout step"
+            )
         pytest.skip("sibling ClawRouter checkout not available")
     top_models = json.loads(top_models_path.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Why

This repo had **no test workflow**. The only CI was the brand-numbers marker check, so nothing but a developer's local run ever executed `tests/`.

That mattered most for the one test that cannot run on a bare runner. `test_curated_picker_catalog_mirrors_clawrouter_top_models` validates the curated catalog against ClawRouter's `top-models.json` and `pytest.skip`s when that file is absent — which, on a runner, was always. The consequence showed up on 2026-08-31: the guard was red on `main` **and** on the open catalog-sync PR at the same time, and both reported green.

## What

- `.github/workflows/tests.yml` — checks this repo out at `ClawRouter-Hermes/` and `BlockRunAI/ClawRouter` at `ClawRouter/`, so `_repo_root().parent / "ClawRouter"` resolves. Both repos are public, so the second checkout needs no token.
- `CLAWROUTER_SIBLING_REQUIRED=1` in CI promotes the skip to a failure. Without it, a renamed path or a broken checkout step would quietly restore the always-green skip this PR exists to remove.

## Verified

| Condition | Result |
| --- | --- |
| sibling present, flag set | `83 passed, 3 skipped` |
| sibling absent, flag set | `1 failed` — `AssertionError: ... top-models.json is missing — check the sibling checkout step` |
| sibling absent, flag unset | `1 skipped` — local dev without a ClawRouter checkout is unaffected |

## Note

The job pins Python 3.13. `requires-python` is `>=3.9` and nothing verifies that floor; adding a matrix is a reasonable follow-up, kept out of here to keep this change to one thing.