### PR TITLE
fix(models): add paid DeepSeek V4 Flash to curated picker

### DIFF
--- a/docs/03-one-endpoint-gpt-claude-gemini-deepseek.md
+++ b/docs/03-one-endpoint-gpt-claude-gemini-deepseek.md
@@ -77,7 +77,7 @@ blockrun/minimax/minimax-m3
 blockrun/moonshot/kimi-k3
 blockrun/deepseek/deepseek-v4-pro
 blockrun/free/nemotron-3.5-lightning
-…55 curated entries (<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models via the gateway)
+…56 curated entries (<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models via the gateway)
 ```
 
 Set the model to `blockrun/auto` and the gateway's router picks a model per request

--- a/src/clawrouter_hermes/models.py
+++ b/src/clawrouter_hermes/models.py
@@ -55,6 +55,7 @@ CHAT_MODELS = (
     "blockrun/qwen/qwen3.8-flash",
     "blockrun/tencent/hy3",
     "blockrun/deepseek/deepseek-v4-flash-vision-exp",
+    "blockrun/deepseek/deepseek-v4-flash",
     "blockrun/deepseek/deepseek-v4-pro",
     "blockrun/deepseek/deepseek-chat",
     "blockrun/deepseek/deepseek-reasoner",

--- a/src/clawrouter_hermes/provider_template/init.py.tmpl
+++ b/src/clawrouter_hermes/provider_template/init.py.tmpl
@@ -90,6 +90,7 @@ _STATIC_FALLBACKS = (
     "blockrun/qwen/qwen3.8-flash",
     "blockrun/tencent/hy3",
     "blockrun/deepseek/deepseek-v4-flash-vision-exp",
+    "blockrun/deepseek/deepseek-v4-flash",
     "blockrun/deepseek/deepseek-v4-pro",
     "blockrun/deepseek/deepseek-chat",
     "blockrun/deepseek/deepseek-reasoner",

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -167,8 +167,6 @@ def test_curated_picker_catalog_orders_featured_models():
         # v0.12.239 dropped it from top-models.json); alias pins keep the id
         # routable at the gateway but it leaves user-facing surfaces.
         "blockrun/free/mistral-large-3-675b",
-        # Never a real SKU: keep the free route ID in the DeepSeek group instead.
-        "blockrun/deepseek/deepseek-v4-flash",
         # Dropped from the live BlockRun catalog by 2026-07-17:
         "blockrun/xai/grok-4-1-fast-reasoning",
         "blockrun/xai/grok-4-0709",

--- a/tests/test_provider_template.py
+++ b/tests/test_provider_template.py
@@ -202,8 +202,12 @@ def test_curated_picker_catalog_orders_featured_models():
 #: ClawRouter ships them. Drop each one from here the moment it lands in
 #: top-models.json — a stale entry silences the guard for a real drift.
 #: Empty since 2026-08-31: ClawRouter #290 landed all four, so the picker
-#: mirrors top-models.json entry for entry again.
-POST_TOP_MODELS_ADDITIONS: frozenset = frozenset()
+#: mirrors top-models.json entry for entry again. Re-populated 2026-09-01 for
+#: the paid deepseek/deepseek-v4-flash, which ships here ahead of ClawRouter
+#: #299 adding it to top-models.json.
+POST_TOP_MODELS_ADDITIONS: frozenset = frozenset(
+    {"blockrun/deepseek/deepseek-v4-flash"},
+)
 
 #: Entries whose picker placement deliberately diverges from top-models.json
 #: order; membership is still enforced. Empty since 2026-08-31 — its only


### PR DESCRIPTION
## Summary

- Add `blockrun/deepseek/deepseek-v4-flash` to `CHAT_MODELS` and the provider template (lockstep). The free `deepseek-v4-flash` route was retired upstream (NVIDIA EOL); the paid route survives but was never a listed SKU, so it had been dropped from the picker rather than shown.
- Remove the paid id from the `retired_models` test guard.
- Bump the docs curated-entry count 55 -> 56.

## Validation

- `pytest`: 83 passed, 3 skipped (live RPC tests skipped).

## Notes

- Verified live on testbed: picker shows `blockrun/deepseek/deepseek-v4-flash` and it routes.