### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 <p>Hermes gives your agent a body. ClawRouter gives it a way to pay.<br>
 No provider accounts. No per-lab keys. Two rails, one provider block.<br><br>
-<strong>One Hermes provider, <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models from 12 labs, paid per request —<br>
+<strong>One Hermes provider, <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models from 12 labs, paid per request —<br>
 USDC from a local wallet, or account credit on one BlockRun key.</strong><br><br>
-<em><!-- br:models.free -->7<!-- /br:models.free --> models free — no crypto, no balance, no signup required.</em></p>
+<em><!-- br:models.free -->6<!-- /br:models.free --> models free — no crypto, no balance, no signup required.</em></p>
 
 <br>
 
-<img src="https://img.shields.io/badge/🆓_<!-- br:models.free -->7<!-- /br:models.free -->_Free_Models-success?style=for-the-badge" alt="free models">&nbsp;
+<img src="https://img.shields.io/badge/🆓_<!-- br:models.free -->6<!-- /br:models.free -->_Free_Models-success?style=for-the-badge" alt="free models">&nbsp;
 <img src="https://img.shields.io/badge/🐍_Hermes_Plugin-black?style=for-the-badge" alt="Hermes plugin">&nbsp;
 <img src="https://img.shields.io/badge/🔑_Wallet_or_API_Key-blue?style=for-the-badge" alt="Wallet or API key">&nbsp;
 <img src="https://img.shields.io/badge/⚡_Smart_Routing-yellow?style=for-the-badge" alt="Smart routing">&nbsp;
@@ -35,7 +35,7 @@ USDC from a local wallet, or account credit on one BlockRun key.</strong><br><br
 
 </div>
 
-> **hermes-plugin-clawrouter** wires [NousResearch Hermes](https://github.com/NousResearch/hermes-agent) into [ClawRouter](https://github.com/BlockRunAI/ClawRouter), the open-source LLM router built for autonomous agents. One `pip install` gives Hermes <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> chat models from OpenAI, Anthropic, Google, xAI, DeepSeek, Moonshot, Z.ai, MiniMax, Qwen, NVIDIA and more — plus image, video and web-search tools — behind a single local provider. Requests are scored across <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions --> dimensions and routed to the cheapest capable model in under 1ms, cutting inference cost by <!-- br:savings.autoVsBaselinePct -->84<!-- /br:savings.autoVsBaselinePct -->% versus pinning Claude Opus 5. Pay however suits you: sign a USDC [x402](https://x402.org) micropayment per call from a local wallet on Solana or Base, **or** sign up at [user.blockrun.ai](https://user.blockrun.ai), top up with a card and use one `brk_…` key. <!-- br:models.free -->7<!-- /br:models.free --> models cost nothing on either rail. MIT licensed.
+> **hermes-plugin-clawrouter** wires [NousResearch Hermes](https://github.com/NousResearch/hermes-agent) into [ClawRouter](https://github.com/BlockRunAI/ClawRouter), the open-source LLM router built for autonomous agents. One `pip install` gives Hermes <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> chat models from OpenAI, Anthropic, Google, xAI, DeepSeek, Moonshot, Z.ai, MiniMax, Qwen, NVIDIA and more — plus image, video and web-search tools — behind a single local provider. Requests are scored across <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions --> dimensions and routed to the cheapest capable model in under 1ms, cutting inference cost by <!-- br:savings.autoVsBaselinePct -->84<!-- /br:savings.autoVsBaselinePct -->% versus pinning Claude Opus 5. Pay however suits you: sign a USDC [x402](https://x402.org) micropayment per call from a local wallet on Solana or Base, **or** sign up at [user.blockrun.ai](https://user.blockrun.ai), top up with a card and use one `brk_…` key. <!-- br:models.free -->6<!-- /br:models.free --> models cost nothing on either rail. MIT licensed.
 
 ---
 
@@ -83,7 +83,7 @@ Stock Hermes wants a **provider block and an API key per lab**. Want Claude *and
 
 ClawRouter collapses the whole thing into one provider:
 
-- **Starts at $0** — <!-- br:models.free -->7<!-- /br:models.free --> free models, usable before you pay anyone anything
+- **Starts at $0** — <!-- br:models.free -->6<!-- /br:models.free --> free models, usable before you pay anyone anything
 - **One provider, every lab** — Hermes' `/model` picker shows the full curated catalog, grouped by provider
 - **No lab keys, ever** — you hold at most one BlockRun credential, never OpenAI's or Anthropic's
 - **Pay how you like** — a wallet signature *or* one `brk_…` key; the plugin follows whichever is configured
@@ -97,8 +97,8 @@ ClawRouter collapses the whole thing into one provider:
 
 |                     | Hermes + lab API keys       | Hermes + OpenRouter | Local Ollama       | **ClawRouter for Hermes**                                             |
 | ------------------- | --------------------------- | ------------------- | ------------------ | --------------------------------------------------------------------- |
-| **Models**          | One provider block per lab  | Many                | Whatever you host  | **<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible -->, one block**            |
-| **Free tier**       | No                          | Rate-limited        | Free but local GPU | **<!-- br:models.free -->7<!-- /br:models.free --> models, no signup** |
+| **Models**          | One provider block per lab  | Many                | Whatever you host  | **<!-- br:models.chatVisible -->78<!-- /br:models.chatVisible -->, one block**            |
+| **Free tier**       | No                          | Rate-limited        | Free but local GPU | **<!-- br:models.free -->6<!-- /br:models.free --> models, no signup** |
 | **Auth**            | An API key per lab          | Account + API key   | None               | **Wallet signature, or one BlockRun key**                             |
 | **Payment**         | Per-lab invoices            | Credit card         | Your electricity   | **USDC per request, or account credit**                               |
 | **Model selection** | Manual                      | Manual              | Manual             | **Automatic (<!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions -->-dim scoring, <1ms)** |
@@ -176,7 +176,7 @@ Check either with `/clawrouter account` in chat, or `hermes-clawrouter account` 
 
 ### Models
 
-The `/model` picker carries a curated, provider-grouped slice of the catalog (small inline keyboards can't render <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> entries); every other model stays routable by full ID.
+The `/model` picker carries a curated, provider-grouped slice of the catalog (small inline keyboards can't render <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> entries); every other model stays routable by full ID.
 
 | Provider          | In the picker                                                                                      |
 | ----------------- | -------------------------------------------------------------------------------------------------- |
@@ -430,7 +430,7 @@ pytest
 
 **ClawRouter for NousResearch Hermes**
 
-You're here. <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models, smart routing, wallet or API key.
+You're here. <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models, smart routing, wallet or API key.
 
 `pip install hermes-plugin-clawrouter`
 
@@ -454,7 +454,7 @@ The canonical TypeScript proxy this plugin wraps. Works with any OpenAI-compatib
 
 **BlockRun for Claude Code**
 
-Claude Code on <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models — no Anthropic account, no rate limits, pay per request.
+Claude Code on <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models — no Anthropic account, no rate limits, pay per request.
 
 `curl -fsSL https://blockrun.ai/brcc-install | bash`
 
@@ -483,7 +483,7 @@ No. It adds one more provider. Existing OpenAI/Anthropic/OAuth blocks in `config
 
 ### Do I need crypto to try it?
 
-No. <!-- br:models.free -->7<!-- /br:models.free --> models are free with no wallet, no balance and no signup. Beyond that you can pay with a card at [user.blockrun.ai](https://user.blockrun.ai) and never touch a wallet at all.
+No. <!-- br:models.free -->6<!-- /br:models.free --> models are free with no wallet, no balance and no signup. Beyond that you can pay with a card at [user.blockrun.ai](https://user.blockrun.ai) and never touch a wallet at all.
 
 ### If I switch to an API key, what happens to my wallet?
 

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -2,17 +2,17 @@
   "$schema": "https://blockrun.ai/brand/numbers.schema.json",
   "version": 1,
   "models": {
-    "chatVisible": 76,
-    "totalVisible": 100,
-    "free": 7,
-    "freeWithheld": 26,
+    "chatVisible": 78,
+    "totalVisible": 102,
+    "free": 6,
+    "freeWithheld": 27,
     "image": 9,
     "video": 8,
     "music": 1,
     "speech": 5,
     "soundfx": 1,
-    "withFallback": 34,
-    "withFallbackAllEntries": 73
+    "withFallback": 33,
+    "withFallbackAllEntries": 74
   },
   "clawrouter": {
     "dimensions": 15,

--- a/docs/01-vision-analyze-connection-error-custom-provider.md
+++ b/docs/01-vision-analyze-connection-error-custom-provider.md
@@ -145,7 +145,7 @@ dominates latency exactly as before.
 
 *If you'd rather not run and maintain your own local proxy, a ready-made option is
 [ClawRouter](https://github.com/BlockRunAI/ClawRouter) — a one-command Hermes plugin
-that serves a local OpenAI-compatible endpoint and gives you <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models — many
+that serves a local OpenAI-compatible endpoint and gives you <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models — many
 vision-capable — behind it. It's one way to implement Fix 2; the diagnosis above
 stands regardless of which proxy you use.*
 

--- a/docs/02-oauth-vision-provider-falls-back-to-auto.md
+++ b/docs/02-oauth-vision-provider-falls-back-to-auto.md
@@ -122,7 +122,7 @@ avoiding the broken OAuth branch.
 
 *If you'd rather not assemble and maintain your own proxy,
 [ClawRouter](https://github.com/BlockRunAI/ClawRouter) is a ready-made Hermes plugin
-that exposes <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models (MiniMax included) as a single local `api_key` provider — one
+that exposes <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models (MiniMax included) as a single local `api_key` provider — one
 way to implement the robust setup above. The diagnosis holds regardless of which proxy
 you use; track the upstream fix in
 [hermes-agent#38685](https://github.com/NousResearch/hermes-agent/issues/38685).*

--- a/docs/03-one-endpoint-gpt-claude-gemini-deepseek.md
+++ b/docs/03-one-endpoint-gpt-claude-gemini-deepseek.md
@@ -1,6 +1,6 @@
 ---
 title: "Run GPT-5, Claude, Gemini and DeepSeek in Nous Hermes From One Endpoint"
-description: "Stop wiring a separate provider, key and OAuth flow for every model in Hermes Agent. Point Hermes at one OpenAI-compatible gateway and switch between <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models from the /model picker."
+description: "Stop wiring a separate provider, key and OAuth flow for every model in Hermes Agent. Point Hermes at one OpenAI-compatible gateway and switch between <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models from the /model picker."
 keywords:
   - hermes multiple llm providers
   - hermes one endpoint all models
@@ -77,7 +77,7 @@ blockrun/minimax/minimax-m3
 blockrun/moonshot/kimi-k3
 blockrun/deepseek/deepseek-v4-pro
 blockrun/free/nemotron-3.5-lightning
-…56 curated entries (<!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> models via the gateway)
+…56 curated entries (<!-- br:models.chatVisible@live -->78<!-- /br:models.chatVisible@live --> models via the gateway)
 ```
 
 Set the model to `blockrun/auto` and the gateway's router picks a model per request
@@ -161,11 +161,11 @@ If you prefer a traditional key-based aggregator, the same one-endpoint config
 pattern works — you just lose the non-custodial/pay-per-use property.
 
 **How many models are available?**
-<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> across OpenAI, Anthropic, Google, DeepSeek, Moonshot/Kimi, xAI/Grok, MiniMax,
+<!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> across OpenAI, Anthropic, Google, DeepSeek, Moonshot/Kimi, xAI/Grok, MiniMax,
 Z.AI/GLM, Qwen, NVIDIA-hosted open models, and more — plus a few free tiers.
 
 ---
 
 *Last reviewed against Hermes Agent v0.18.x. The single-endpoint pattern is provider-
 agnostic; ClawRouter is the implementation that adds non-custodial pay-per-call
-billing and <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models behind the one URL.*
+billing and <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models behind the one URL.*

--- a/docs/04-pay-per-call-llm-no-api-keys-hermes.md
+++ b/docs/04-pay-per-call-llm-no-api-keys-hermes.md
@@ -1,6 +1,6 @@
 ---
 title: "Pay-Per-Call LLM Access for Hermes Agents — No API Keys, No Subscriptions"
-description: "Funding and rotating an API key for every model your Hermes agent uses is a chore and a liability. Here's how to give Hermes keyless, pay-per-call access to <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models with USDC micropayments from a wallet you control."
+description: "Funding and rotating an API key for every model your Hermes agent uses is a chore and a liability. Here's how to give Hermes keyless, pay-per-call access to <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models with USDC micropayments from a wallet you control."
 keywords:
   - hermes no api key llm
   - hermes pay per use llm
@@ -49,7 +49,7 @@ Applied to LLM access, that means:
 
 [ClawRouter](https://github.com/BlockRunAI/ClawRouter) implements this for Hermes. It
 runs a local OpenAI-compatible gateway that signs an x402 payment for each upstream
-call and routes to <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models:
+call and routes to <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/BlockRunAI/ClawRouter-Hermes/main/scripts/install.sh | bash

--- a/src/clawrouter_hermes/skills/clawrouter/SKILL.md
+++ b/src/clawrouter_hermes/skills/clawrouter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawrouter
-description: Hosted-gateway LLM router — save 87% on inference costs. A local proxy that forwards each request to the blockrun.ai gateway, which routes to the cheapest capable model across <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models from OpenAI, Anthropic, Google, DeepSeek, xAI, NVIDIA, and more. <!-- br:models.free -->7<!-- /br:models.free --> free models included. Also exposes realtime market data (global stocks, crypto, FX, commodities), Twitter/X intelligence, and prediction-market data across Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, dFlow + UMA oracle resolution + wallet identity & clustering as built-in agent tools. Not a local-inference tool — prompts are sent to the blockrun.ai gateway.
+description: Hosted-gateway LLM router — save 87% on inference costs. A local proxy that forwards each request to the blockrun.ai gateway, which routes to the cheapest capable model across <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models from OpenAI, Anthropic, Google, DeepSeek, xAI, NVIDIA, and more. <!-- br:models.free -->6<!-- /br:models.free --> free models included. Also exposes realtime market data (global stocks, crypto, FX, commodities), Twitter/X intelligence, and prediction-market data across Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, dFlow + UMA oracle resolution + wallet identity & clustering as built-in agent tools. Not a local-inference tool — prompts are sent to the blockrun.ai gateway.
 triggers:
   - "clawrouter"
   - "claw router"
@@ -65,7 +65,7 @@ basics through common OS package managers when available.
 
 Then in a Hermes chat session:
 
-- Pick model `blockrun/auto` for smart routing across <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models.
+- Pick model `blockrun/auto` for smart routing across <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models.
 - `/clawrouter account` — which rail you're paying on (wallet or API key)
 - `/clawrouter wallet` — show address + USDC balance (Solana and Base)
 - `/clawrouter stats` — proxy usage
@@ -100,7 +100,7 @@ Wallet lives at `~/.openclaw/blockrun/mnemonic` (shared with the upstream TS CLI
 
 ---
 
-Hosted-gateway LLM router that saves <!-- br:savings.autoVsBaselinePct -->84<!-- /br:savings.autoVsBaselinePct -->% on inference costs by forwarding each request to the blockrun.ai gateway, which picks the cheapest model capable of handling it across <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models from 12 providers (<!-- br:models.free -->7<!-- /br:models.free --> free models). Billing flows through one credential — a local USDC wallet, or one BlockRun API key from https://user.blockrun.ai. Either way you do not hold provider API keys.
+Hosted-gateway LLM router that saves <!-- br:savings.autoVsBaselinePct -->84<!-- /br:savings.autoVsBaselinePct -->% on inference costs by forwarding each request to the blockrun.ai gateway, which picks the cheapest model capable of handling it across <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models from 12 providers (<!-- br:models.free -->6<!-- /br:models.free --> free models). Billing flows through one credential — a local USDC wallet, or one BlockRun API key from https://user.blockrun.ai. Either way you do not hold provider API keys.
 
 **This is not a local-inference tool.** ClawRouter is a thin local proxy. Your prompts are sent over HTTPS to the blockrun.ai gateway for model execution. If your workload requires inference that never leaves your machine, use a local runtime like Ollama — ClawRouter is not the right tool for that use case.
 
@@ -192,7 +192,7 @@ Rules handle ~80% of requests in <1ms. Only ambiguous queries hit the LLM classi
 
 ## Available Models
 
-<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models including: claude-fable-5, claude-opus-5, claude-opus-4.8, claude-opus-4.7, claude-sonnet-5, claude-sonnet-4.6, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gemini-3.1-pro, gemini-3.5-flash, grok-4.5, grok-4.3, grok-build-0.1, deepseek-v4-pro, deepseek-v4-flash-vision-exp [vision], deepseek-chat, glm-5.2, kimi-k3, minimax-m3, qwen3.7-max, and the curated free models (nemotron-3.5-lightning, nemotron-3-nano-30b, laguna-xs-2.1, north-mini-code, nemotron-3-nano-omni-30b-a3b-reasoning [vision], nemotron-3-ultra-550b, llama-3.2-11b-vision [vision]).
+<!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models including: claude-fable-5, claude-opus-5, claude-opus-4.8, claude-opus-4.7, claude-sonnet-5, claude-sonnet-4.6, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gemini-3.1-pro, gemini-3.5-flash, grok-4.5, grok-4.3, grok-build-0.1, deepseek-v4-pro, deepseek-v4-flash-vision-exp [vision], deepseek-chat, glm-5.2, kimi-k3, minimax-m3, qwen3.7-max, and the curated free models (nemotron-3.5-lightning, nemotron-3-nano-30b, laguna-xs-2.1, north-mini-code, nemotron-3-nano-omni-30b-a3b-reasoning [vision], nemotron-3-ultra-550b, llama-3.2-11b-vision [vision]).
 
 ## Built-in Agent Tools
 


### PR DESCRIPTION
`brand-numbers.json` in this repo was behind the published artifact, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. `--check` is offline by design so PR CI stays deterministic, which means it validates against this repo's **own** snapshot; only `--refresh` updates that snapshot.

Opened automatically by [`brand/fanout-brand-numbers.mjs`](https://github.com/BlockRunAI/blockrun/blob/main/brand/fanout-brand-numbers.mjs). Produced by `--refresh`, no hand-edited digits.