### PR TITLE
feat: forward TWZRD AutoGate to proxy and bundle pre-sign x402 hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ Configuring an API key does **not** touch any of this. The mnemonic stays where 
 | `BLOCKRUN_WALLET_KEY` | Raw EVM hex private key — overrides the mnemonic file. |
 | `CLAWROUTER_PAYMENT_CHAIN` | `solana` / `base`. Wins over both chain files. Wallet rail only — an API key has no chain to sign on. |
 | `CLAWROUTER_ROUTING_PROFILE` | `eco` / `auto` / `premium`. Forwarded to the proxy on spawn. |
+| `TWZRD_AUTO_GATE=1` | Opt-in TWZRD wash on the **Node proxy** (ClawRouter #357). Copied into the spawned process via `_build_env()` (`dict(os.environ)`). Must be in the **Hermes gateway** environment, not only an interactive shell. Default off. |
+| `TWZRD_FAIL_OPEN=false` | On that same proxy, refuse if intel times out. ClawRouter default is fail-open on timeout. |
+
+Python tools that pay with `x402Client` (not 8402) must register `clawrouter_hermes.twzrd_before_sign.create_before_sign_hook` themselves. Skill `twzrd-before-sign` documents that path. It does not wrap Node signing.
 
 > **`CLAWROUTER_API_KEY` is not `BLOCKRUN_API_KEY`.** The names sit one word apart and mean opposite things. `CLAWROUTER_API_KEY` is a non-secret placeholder (`clawrouter-local`) that exists only because Hermes hides API-key-style providers from `/model` unless their key env var is set — putting a `brk_…` key there does nothing, since the local proxy replaces the client's `authorization` header on the way upstream. `BLOCKRUN_API_KEY` is the one that spends money.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ clawrouter_hermes = [
     "provider_template/*.yaml",
     "provider_template/*.tmpl",
     "skills/clawrouter/*.md",
+    "skills/twzrd-before-sign/*.md",
 ]
 
 [tool.pytest.ini_options]

--- a/src/clawrouter_hermes/__init__.py
+++ b/src/clawrouter_hermes/__init__.py
@@ -261,15 +261,23 @@ def _register_cli(ctx) -> None:
 
 
 def _register_skill(ctx) -> None:
-    skill_path = Path(__file__).parent / "skills" / "clawrouter" / "SKILL.md"
-    if not skill_path.exists():
-        logger.debug("clawrouter: skill file missing at %s", skill_path)
-        return
-    try:
-        ctx.register_skill(
-            name="guide",
-            path=skill_path,
-            description="ClawRouter usage guide — models, pricing, wallet, slash commands",
-        )
-    except Exception as exc:
-        logger.debug("clawrouter: skill registration failed: %s", exc)
+    skills = (
+        (
+            "guide",
+            Path(__file__).parent / "skills" / "clawrouter" / "SKILL.md",
+            "ClawRouter usage guide — models, pricing, wallet, slash commands",
+        ),
+        (
+            "twzrd-before-sign",
+            Path(__file__).parent / "skills" / "twzrd-before-sign" / "SKILL.md",
+            "Opt-in TWZRD wash hook for Python x402Client tools (not Node proxy inference)",
+        ),
+    )
+    for name, skill_path, description in skills:
+        if not skill_path.exists():
+            logger.debug("clawrouter: skill file missing at %s", skill_path)
+            continue
+        try:
+            ctx.register_skill(name=name, path=skill_path, description=description)
+        except Exception as exc:
+            logger.debug("clawrouter: skill %s registration failed: %s", name, exc)

--- a/src/clawrouter_hermes/proxy_supervisor.py
+++ b/src/clawrouter_hermes/proxy_supervisor.py
@@ -186,6 +186,16 @@ def _build_env() -> dict:
     # Tag the proxy's User-Agent as Hermes-originated. setdefault so an explicit
     # user-set CLAWROUTER_CLIENT wins.
     env.setdefault("CLAWROUTER_CLIENT", _CLIENT_TAG)
+    # TWZRD_AUTO_GATE / TWZRD_FAIL_OPEN are copied with os.environ above — do
+    # not setdefault them on. Node AutoGate (#357) stays opt-in. If they are
+    # set in the Hermes process (gateway env, not only an interactive shell),
+    # the spawned proxy sees the same values.
+    if env.get("TWZRD_AUTO_GATE") or env.get("TWZRD_GATE_ENABLED"):
+        logger.info(
+            "clawrouter: forwarding TWZRD AutoGate flags to proxy (TWZRD_AUTO_GATE=%s TWZRD_FAIL_OPEN=%s)",
+            env.get("TWZRD_AUTO_GATE", ""),
+            env.get("TWZRD_FAIL_OPEN", ""),
+        )
     return env
 
 

--- a/src/clawrouter_hermes/skills/twzrd-before-sign/SKILL.md
+++ b/src/clawrouter_hermes/skills/twzrd-before-sign/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: twzrd-before-sign
+description: Fail-closed wash screen for a Python x402Client used by a Hermes skill. Does not protect ClawRouter Node-proxy inference payments.
+---
+
+# TWZRD before signing (Python tools only)
+
+Two payment boundaries in ClawRouter-Hermes:
+
+1. **LLM inference** goes to `http://127.0.0.1:8402` and is signed by the **Node** proxy. Enable that with `TWZRD_AUTO_GATE=1` in the **Hermes gateway** environment (this plugin already copies `os.environ` into the spawned proxy). That is ClawRouter #357, not this skill.
+2. **Python tools** that call `x402Client` themselves do **not** go through 8402. Wire this hook on that client:
+
+```python
+from clawrouter_hermes.twzrd_before_sign import create_before_sign_hook
+
+client.on_before_payment_creation(create_before_sign_hook(timeout_seconds=2))
+```
+
+Requires `x402[evm,svm]==2.13.1` and `solana==0.36.6` (x402 2.13.1 imports an RPC module missing from solana 0.40.3). Installing this skill does not grant wallet authority.
+
+Wash, missing/partial/stale coverage, timeout, and intel errors abort. `wash_flagged: false` without full coverage is unknown, not clean. Not Path B / not independent adoption.

--- a/src/clawrouter_hermes/twzrd_before_sign.py
+++ b/src/clawrouter_hermes/twzrd_before_sign.py
@@ -1,0 +1,63 @@
+"""Opt-in TWZRD wash guard for an official async Python x402 client.
+
+Register on the payment client used by a Hermes *skill/tool*, before requests.
+Does not intercept the Node ClawRouter proxy (LLM inference 402s). No wallet
+access, no default-on, no global monkeypatch.
+"""
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import quote
+
+import httpx
+
+
+def create_before_sign_hook(*, timeout_seconds: float = 2.0, transport=None):
+    """Fail closed on flagged, incomplete, stale, or unavailable wash evidence.
+
+    ``transport`` is an httpx transport for offline tests. Production origin is
+    fixed; a challenge-supplied URL cannot redirect intelligence requests.
+    Requires the official ``x402`` package at call time (not a plugin dep).
+    """
+    if not 0 < timeout_seconds <= 30:
+        raise ValueError("timeout_seconds must be between 0 and 30")
+    from x402.schemas import AbortResult  # lazy: plugin must load without x402
+
+    async def hook(context):
+        requirements = context.selected_requirements
+        if not requirements.pay_to or not (
+            requirements.network == "eip155:8453"
+            or requirements.network.startswith("solana:")
+        ):
+            return AbortResult(reason="twzrd_unsupported_payment")
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                async with httpx.AsyncClient(
+                    transport=transport,
+                    timeout=timeout_seconds,
+                    follow_redirects=False,
+                    trust_env=False,
+                ) as http:
+                    response = await http.get(
+                        "https://intel.twzrd.xyz/v1/intel/merchant_card/"
+                        + quote(requirements.pay_to, safe=""),
+                    )
+                    response.raise_for_status()
+                    card = response.json()
+                    if not isinstance(card, dict):
+                        return AbortResult(reason="twzrd_wash_unknown")
+                    if card.get("wash_flagged") is True:
+                        return AbortResult(reason="twzrd_wash_detected")
+                    if not (
+                        card.get("wash_flagged") is False
+                        and str(card.get("wash_confidence", "")).strip().lower() == "full"
+                        and card.get("ring_evaluated") is not False
+                        and card.get("wash_stale") is not True
+                        and card.get("stale") is not True
+                    ):
+                        return AbortResult(reason="twzrd_wash_unknown")
+        except (httpx.HTTPError, ValueError, TimeoutError):
+            return AbortResult(reason="twzrd_intel_unavailable")
+        return None
+
+    return hook

--- a/tests/test_proxy_supervisor.py
+++ b/tests/test_proxy_supervisor.py
@@ -108,6 +108,20 @@ def test_build_env_respects_explicit_client_override(isolated_home, monkeypatch)
     assert env["CLAWROUTER_CLIENT"] == "custom-host/9.9"
 
 
+def test_build_env_forwards_twzrd_flags_without_defaulting_them_on(isolated_home, monkeypatch):
+    from clawrouter_hermes import proxy_supervisor
+
+    monkeypatch.delenv("TWZRD_AUTO_GATE", raising=False)
+    monkeypatch.delenv("TWZRD_FAIL_OPEN", raising=False)
+    env = proxy_supervisor._build_env()
+    assert "TWZRD_AUTO_GATE" not in env or not env.get("TWZRD_AUTO_GATE")
+    monkeypatch.setenv("TWZRD_AUTO_GATE", "1")
+    monkeypatch.setenv("TWZRD_FAIL_OPEN", "false")
+    env = proxy_supervisor._build_env()
+    assert env["TWZRD_AUTO_GATE"] == "1"
+    assert env["TWZRD_FAIL_OPEN"] == "false"
+
+
 # ---------------------------------------------------------------------------
 # Auth-rail guards. Both of these are money bugs when they regress: one spends
 # the wallet a customer parked, the other bills the account they logged out of.


### PR DESCRIPTION
Two payment boundaries, two reflexes. This PR does not conflate them.

## Node proxy (LLM inference → :8402)
\`_build_env()\` already does \`dict(os.environ)\`. \`TWZRD_AUTO_GATE\` / \`TWZRD_FAIL_OPEN\` already reach \`npx @blockrun/clawrouter\` if they are in the **Hermes gateway** environment. This PR:
- documents that (README)
- logs when AutoGate flags are present
- tests they are **not** defaulted on

That is ClawRouter #357 on the spawned proxy. Default remains off.

## Python tools (x402Client in-process)
Those payments never hit 8402. Bundle:
- \`clawrouter_hermes.twzrd_before_sign.create_before_sign_hook\` (lazy-import \`x402\`; not a plugin dependency)
- skill \`twzrd-before-sign\`

Wash / unknown / timeout abort. \`wash_flagged: false\` without full coverage is unknown. Not Path B.

Tests: \`tests/test_proxy_supervisor.py\` 19 passed (includes env-forward). SVM/EVM signer-count tests live in the adjacent \`hermes-twzrd-preflight\` tree (x402 2.13.1 + solana 0.36.6) and are not pulled into this plugin’s CI.