### PR TITLE
feat: bundle TWZRD pre-sign x402 hook and verify proxy env forwarding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  twzrd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install -e ".[dev,twzrd]"
+      - run: python -m pytest -q tests/test_twzrd.py tests/test_twzrd_svm.py tests/test_twzrd_integration.py
+
   pytest:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -518,3 +518,18 @@ Yes — set `CLAWROUTER_PROXY_URL` and the plugin skips the local spawn entirely
 ⭐ If ClawRouter powers your Hermes agent, consider starring the repo!
 
 </div>
+
+### Optional TWZRD payment screening
+
+For Python 3.11+ tool scripts, install `hermes-plugin-clawrouter[twzrd]` and
+register `clawrouter_hermes.twzrd.create_before_sign_hook()` on their official
+async x402 client. The bundled `twzrd-before-sign` skill explains wiring and
+scope. Installation does not automatically protect arbitrary tool payments.
+The optional extra pins Solana 0.36.10 because x402 2.13.1 imports the synchronous
+RPC module absent from Solana 0.40.3.
+
+For Node proxy x402 payments, set `TWZRD_AUTO_GATE=1` and
+`TWZRD_FAIL_OPEN=false` before startup. Existing environment inheritance forwards
+both flags to newly spawned proxies. Reused/external proxies need their own
+configuration; verify the Node gate package resolves and AutoGate activates.
+The Python hook neither changes proxy policy nor screens API-key billing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+twzrd = [
+    "x402[evm,svm]==2.13.1; python_version >= '3.11'",
+    "solana==0.36.10; python_version >= '3.11'",
+]
+
 dev = [
     "pytest>=7",
     "pytest-asyncio>=0.23",
@@ -56,6 +61,7 @@ clawrouter_hermes = [
     "provider_template/*.yaml",
     "provider_template/*.tmpl",
     "skills/clawrouter/*.md",
+    "skills/twzrd-before-sign/*.md",
 ]
 
 [tool.pytest.ini_options]

--- a/src/clawrouter_hermes/__init__.py
+++ b/src/clawrouter_hermes/__init__.py
@@ -39,6 +39,7 @@ def register(ctx) -> None:
     _register_slash_command(ctx)
     _register_cli(ctx)
     _register_skill(ctx)
+    _register_twzrd_skill(ctx)
     # Best-effort, non-blocking probe so users see whether the proxy is up
     # without paying spawn latency at startup.
     try:
@@ -273,3 +274,15 @@ def _register_skill(ctx) -> None:
         )
     except Exception as exc:
         logger.debug("clawrouter: skill registration failed: %s", exc)
+
+
+def _register_twzrd_skill(ctx) -> None:
+    """Expose opt-in instructions without importing optional payment dependencies."""
+    try:
+        ctx.register_skill(
+            name="twzrd-before-sign",
+            path=Path(__file__).parent / "skills" / "twzrd-before-sign" / "SKILL.md",
+            description="Opt-in pre-sign wash screening for Python x402 clients",
+        )
+    except Exception as exc:
+        logger.debug("clawrouter: TWZRD skill registration failed: %s", exc)

--- a/src/clawrouter_hermes/skills/twzrd-before-sign/SKILL.md
+++ b/src/clawrouter_hermes/skills/twzrd-before-sign/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: twzrd-before-sign
+description: Opt-in wash screening before signing payments in an explicitly wired Python x402 client.
+---
+
+# TWZRD before signing
+
+Use Python 3.11+ and install `hermes-plugin-clawrouter[twzrd]` in the payment
+script's environment. Preserve the operator's wallet authority and spend policy.
+Never put wallet keys in prompts. Register on the actual async payment client:
+
+```python
+from clawrouter_hermes.twzrd import create_before_sign_hook
+
+client.on_before_payment_creation(create_before_sign_hook())
+```
+
+The client must already have its signer and local spending policy configured.
+This hook queries the free TWZRD merchant card for the selected payTo. Flagged,
+unknown, partial, stale, or unavailable wash evidence aborts before signing.
+Full negative wash evidence permits continuation; it does not certify merchant
+safety. Base and Solana challenges are supported. Intel receives the payee and
+connection metadata; no attribution identifiers are added.
+
+Skill registration alone does not intercept payments. Other clients, MPP,
+arbitrary tools, and direct wallet calls remain outside this hook.
+
+## Node inference proxy (separate boundary)
+
+Set `TWZRD_AUTO_GATE=1` and `TWZRD_FAIL_OPEN=false` before launching the plugin.
+The supervisor inherits these into newly spawned proxies. A reused or external
+proxy must be configured and restarted by its operator. Environment forwarding
+alone does not prove AutoGate activation: the Node proxy needs a compatible
+ClawRouter and resolvable gate package. Verify its loaded version and activation.
+The Python hook does not change the Node proxy or protect API-key billing.

--- a/src/clawrouter_hermes/twzrd.py
+++ b/src/clawrouter_hermes/twzrd.py
@@ -1,0 +1,61 @@
+"""Opt-in TWZRD wash guard for an official async Python x402 client.
+
+Register on the payment client used by the Hermes skill, before making requests.
+No wallet access, telemetry identifiers, paid requests, or global monkeypatches.
+"""
+import asyncio
+from urllib.parse import quote
+
+import httpx
+import sys
+
+
+def create_before_sign_hook(*, timeout_seconds=2.0, transport=None):
+    """Fail closed on flagged, incomplete, stale, or unavailable wash evidence.
+
+    transport is an httpx transport for offline tests. The production origin is
+    fixed; no challenge-supplied URL can redirect intelligence requests.
+    """
+    if sys.version_info < (3, 11):
+        raise RuntimeError("The TWZRD hook requires Python 3.11+ and the twzrd extra")
+    from x402.schemas import AbortResult, PaymentCreationContext
+
+    if not 0 < timeout_seconds <= 30:
+        raise ValueError("timeout_seconds must be between 0 and 30")
+
+    async def hook(context: PaymentCreationContext):
+        requirements = context.selected_requirements
+        if not requirements.pay_to or not (
+            requirements.network == "eip155:8453"
+            or requirements.network.startswith("solana:")
+        ):
+            return AbortResult(reason="twzrd_unsupported_payment")
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                async with httpx.AsyncClient(
+                    transport=transport, timeout=timeout_seconds,
+                    follow_redirects=False, trust_env=False,
+                ) as http:
+                    response = await http.get(
+                        "https://intel.twzrd.xyz/v1/intel/merchant_card/"
+                        + quote(requirements.pay_to, safe=""),
+                    )
+                    response.raise_for_status()
+                    card = response.json()
+                    if not isinstance(card, dict):
+                        return AbortResult(reason="twzrd_wash_unknown")
+                    if card.get("wash_flagged") is True:
+                        return AbortResult(reason="twzrd_wash_detected")
+                    if not (
+                        card.get("wash_flagged") is False
+                        and str(card.get("wash_confidence", "")).strip().lower() == "full"
+                        and card.get("ring_evaluated") is not False
+                        and card.get("wash_stale") is not True
+                        and card.get("stale") is not True
+                    ):
+                        return AbortResult(reason="twzrd_wash_unknown")
+        except (httpx.HTTPError, ValueError, TimeoutError):
+            return AbortResult(reason="twzrd_intel_unavailable")
+        return None
+
+    return hook

--- a/tests/test_twzrd.py
+++ b/tests/test_twzrd.py
@@ -1,0 +1,121 @@
+import asyncio
+import base64
+
+import httpx
+import pytest
+
+pytest.importorskip("x402")
+from eth_account import Account
+from x402 import x402Client
+from x402.mechanisms.evm import EthAccountSigner
+from x402.mechanisms.evm.exact import ExactEvmScheme
+from x402.schemas import PaymentAbortedError, PaymentRequired
+
+from clawrouter_hermes.twzrd import create_before_sign_hook
+
+
+@pytest.mark.parametrize("guarded", [False, True])
+def test_http_challenge_through_real_transport(guarded):
+    from x402.http.clients.httpx import PaymentError, x402AsyncTransport
+    signer = CountingSigner()
+    client = x402Client().register("eip155:8453", ExactEvmScheme(signer))
+    if guarded:
+        client.on_before_payment_creation(create_before_sign_hook(
+            transport=httpx.MockTransport(lambda req: httpx.Response(200, json={"wash_flagged": True})),
+        ))
+    seen = []
+    def merchant(request):
+        seen.append(request)
+        if request.headers.get("payment-signature"):
+            return httpx.Response(200, text="fixture")
+        encoded = base64.b64encode(challenge().model_dump_json(by_alias=True).encode()).decode()
+        return httpx.Response(402, headers={"payment-required": encoded})
+    async def request():
+        async with httpx.AsyncClient(transport=x402AsyncTransport(client, httpx.MockTransport(merchant))) as http:
+            return await http.get("https://merchant.example/resource")
+    if guarded:
+        with pytest.raises(PaymentError, match="twzrd_wash_detected") as error:
+            asyncio.run(request())
+        assert isinstance(error.value.__cause__, PaymentAbortedError)
+        assert signer.calls == 0
+        assert len(seen) == 1
+    else:
+        assert asyncio.run(request()).status_code == 200
+        assert signer.calls == 1
+        assert len(seen) == 2
+
+
+class CountingSigner(EthAccountSigner):
+    def __init__(self):
+        super().__init__(Account.create())  # ephemeral, unfunded; never persisted
+        self.calls = 0
+
+    def sign_typed_data(self, *args, **kwargs):
+        self.calls += 1
+        return super().sign_typed_data(*args, **kwargs)
+
+
+def challenge():
+    return PaymentRequired.model_validate({
+        "x402Version": 2,
+        "resource": {"url": "https://merchant.example/resource"},
+        "accepts": [{
+            "scheme": "exact", "network": "eip155:8453", "amount": "50000",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "payTo": "0x1111111111111111111111111111111111111111",
+            "maxTimeoutSeconds": 60, "extra": {"name": "USD Coin", "version": "2"},
+        }],
+    })
+
+
+@pytest.mark.parametrize("card,reason", [
+    ({"wash_flagged": True}, "twzrd_wash_detected"),
+    ({"wash_flagged": None}, "twzrd_wash_unknown"),
+    ({"wash_flagged": False}, "twzrd_wash_unknown"),
+    ({"wash_flagged": False, "wash_confidence": "partial"}, "twzrd_wash_unknown"),
+    ({"wash_flagged": False, "wash_confidence": "full", "stale": True}, "twzrd_wash_unknown"),
+    ([], "twzrd_wash_unknown"),
+    ({"wash_flagged": False, "wash_confidence": "full", "ring_evaluated": True}, None),
+])
+def test_real_client_signing_boundary(card, reason):
+    signer = CountingSigner()
+    client = x402Client().register("eip155:8453", ExactEvmScheme(signer))
+    requests = []
+
+    def intel(request):
+        requests.append(request)
+        return httpx.Response(200, json=card)
+
+    client.on_before_payment_creation(create_before_sign_hook(transport=httpx.MockTransport(intel)))
+    if reason:
+        with pytest.raises(PaymentAbortedError, match=reason):
+            asyncio.run(client.create_payment_payload(challenge()))
+        assert signer.calls == 0
+    else:
+        payload = asyncio.run(client.create_payment_payload(challenge()))
+        assert payload.payload["signature"]
+        assert signer.calls == 1
+    assert len(requests) == 1
+    assert requests[0].url.path.endswith(challenge().accepts[0].pay_to)
+
+
+@pytest.mark.parametrize("failure", ["timeout", "http", "json", "redirect"])
+def test_intel_failure_never_signs(failure):
+    signer = CountingSigner()
+    client = x402Client().register("eip155:8453", ExactEvmScheme(signer))
+
+    async def intel(request):
+        if failure == "timeout":
+            await asyncio.sleep(1)
+        if failure == "http":
+            return httpx.Response(503)
+        if failure == "redirect":
+            return httpx.Response(302, headers={"location": "https://other.example"})
+        return httpx.Response(200, text="not JSON")
+
+    client.on_before_payment_creation(create_before_sign_hook(
+        timeout_seconds=0.05, transport=httpx.MockTransport(intel),
+    ))
+    with pytest.raises(PaymentAbortedError, match="twzrd_intel_unavailable"):
+        asyncio.run(client.create_payment_payload(challenge()))
+    assert signer.calls == 0

--- a/tests/test_twzrd_integration.py
+++ b/tests/test_twzrd_integration.py
@@ -1,0 +1,32 @@
+from unittest.mock import Mock
+
+
+def test_spawn_preserves_explicit_twzrd_flags(isolated_home, monkeypatch):
+    from clawrouter_hermes import proxy_supervisor as supervisor
+    monkeypatch.setenv("TWZRD_AUTO_GATE", "1")
+    monkeypatch.setenv("TWZRD_FAIL_OPEN", "false")
+    monkeypatch.setattr(supervisor, "_spawn_cmd", lambda port: (["fake-proxy"], None))
+    popen = Mock()
+    monkeypatch.setattr(supervisor.subprocess, "Popen", popen)
+    supervisor._spawn(8402)
+    env = popen.call_args.kwargs["env"]
+    assert env["TWZRD_AUTO_GATE"] == "1"
+    assert env["TWZRD_FAIL_OPEN"] == "false"
+
+
+def test_unset_flags_remain_unset(isolated_home, monkeypatch):
+    from clawrouter_hermes import proxy_supervisor as supervisor
+    monkeypatch.delenv("TWZRD_AUTO_GATE", raising=False)
+    monkeypatch.delenv("TWZRD_FAIL_OPEN", raising=False)
+    env = supervisor._build_env()
+    assert "TWZRD_AUTO_GATE" not in env
+    assert "TWZRD_FAIL_OPEN" not in env
+
+
+def test_bundled_skill_registration():
+    from clawrouter_hermes import _register_twzrd_skill
+    ctx = Mock()
+    _register_twzrd_skill(ctx)
+    args = ctx.register_skill.call_args.kwargs
+    assert args["name"] == "twzrd-before-sign"
+    assert "clawrouter_hermes.twzrd" in args["path"].read_text()

--- a/tests/test_twzrd_svm.py
+++ b/tests/test_twzrd_svm.py
@@ -1,0 +1,93 @@
+"""Real SVM transaction construction/signing; no RPC or payment broadcast."""
+import asyncio
+import base64
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+pytest.importorskip("x402")
+pytest.importorskip("solders")
+from solders.hash import Hash
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+from solders.transaction import VersionedTransaction
+from x402 import x402Client
+from x402.mechanisms.svm.constants import TOKEN_PROGRAM_ADDRESS
+from x402.mechanisms.svm.exact import ExactSvmScheme
+from x402.mechanisms.svm.signers import KeypairSigner
+from x402.schemas import PaymentAbortedError, PaymentRequired
+
+from clawrouter_hermes.twzrd import create_before_sign_hook
+
+
+class CountingKeypair:
+    def __init__(self):
+        self.inner = Keypair()  # Ephemeral and unfunded.
+        self.calls = 0
+
+    def pubkey(self):
+        return self.inner.pubkey()
+
+    def sign_message(self, message):
+        self.calls += 1
+        return self.inner.sign_message(message)
+
+
+@pytest.mark.parametrize("card,reason", [
+    ({"wash_flagged": True}, "twzrd_wash_detected"),
+    ({"wash_flagged": None}, "twzrd_wash_unknown"),
+    ({"wash_flagged": False}, "twzrd_wash_unknown"),
+    ({"wash_flagged": False, "wash_confidence": "partial"}, "twzrd_wash_unknown"),
+    ({"wash_flagged": False, "wash_confidence": "full", "stale": True}, "twzrd_wash_unknown"),
+    ({"wash_flagged": False, "wash_confidence": "full", "ring_evaluated": True}, None),
+])
+def test_svm_signing_boundary(monkeypatch, card, reason):
+    keypair = CountingKeypair()
+    scheme = ExactSvmScheme(KeypairSigner(keypair))
+    rpc = Mock()
+    rpc.get_latest_blockhash.return_value = SimpleNamespace(
+        value=SimpleNamespace(blockhash=Hash.default()))
+    get_rpc = Mock(return_value=rpc)
+    monkeypatch.setattr(scheme, "_get_client", get_rpc)
+    metadata = Mock(return_value=SimpleNamespace(
+        token_program=Pubkey.from_string(TOKEN_PROGRAM_ADDRESS), decimals=6))
+    monkeypatch.setattr(
+        "x402.mechanisms.svm.exact.client.get_cached_mint_metadata", metadata)
+    network = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+    payee = str(Keypair().pubkey())
+    required = PaymentRequired.model_validate({
+        "x402Version": 2,
+        "resource": {"url": "https://merchant.example/resource"},
+        "accepts": [{
+            "scheme": "exact", "network": network, "amount": "50000",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "payTo": payee, "maxTimeoutSeconds": 60,
+            "extra": {"feePayer": str(Keypair().pubkey())},
+        }],
+    })
+    seen = []
+
+    def intel(request):
+        seen.append(request)
+        return httpx.Response(200, json=card)
+
+    client = x402Client().register(network, scheme)
+    client.on_before_payment_creation(create_before_sign_hook(
+        transport=httpx.MockTransport(intel)))
+    if reason:
+        with pytest.raises(PaymentAbortedError, match=reason):
+            asyncio.run(client.create_payment_payload(required))
+        assert keypair.calls == 0
+        get_rpc.assert_not_called()
+        metadata.assert_not_called()
+    else:
+        payload = asyncio.run(client.create_payment_payload(required))
+        tx = VersionedTransaction.from_bytes(base64.b64decode(payload.payload["transaction"]))
+        assert keypair.calls == 1
+        # Facilitator has not signed; the actual client's signature verifies.
+        assert tx.verify_with_results() == [False, True]
+        rpc.get_latest_blockhash.assert_called_once()
+    assert len(seen) == 1
+    assert seen[0].url.path.endswith(payee)


### PR DESCRIPTION
Python tools using their own x402 client currently have no bundled pre-sign wash hook. Add `clawrouter_hermes.twzrd.create_before_sign_hook()` and register the accompanying `twzrd-before-sign` skill through the existing plugin context. Installing the skill alone does not intercept payments: the tool must register the callback on its actual async x402 client.

The optional `[twzrd]` extra supports Python 3.11+ without changing base plugin dependencies or Python requirements. It uses the official x402 before-payment lifecycle and refuses flagged, unknown, partial, stale, or unavailable merchant-card evidence. Full negative wash evidence permits continuation; it is not a general merchant safety judgment. The intel service receives the selected payee and normal connection metadata.

Proxy environment forwarding already exists via `dict(os.environ)` into `Popen`; regression tests now cover explicit TWZRD_AUTO_GATE/TWZRD_FAIL_OPEN propagation and unchanged unset defaults. No redundant supervisor code or default-policy change. Reused/external proxies require their own configuration, and forwarding does not prove that the Node gate package resolved or activated. API-key billing and arbitrary Python tools remain outside this hook.

Validation:
- Full suite: 142 passed, 4 skipped (existing optional/live/sibling checks).
- Real EVM and SVM SDK signing: refusal calls the signer zero times; full negative evidence signs once. Allowed SVM client signature cryptographically verified with offline RPC fixtures.
- HTTP 402 transport refuses without paid retry and preserves PaymentAbortedError as the wrapped cause.
- Fresh wheel install with `[twzrd]`, dependency compatibility check, packaged helper/skill smoke test passed.
- Brand-numbers and diff checks passed; dedicated optional-extra CI job added.

The extra pins solana==0.36.10: 0.40.3 removes the synchronous RPC module x402 imports, while 0.36.6 conflicts with x402's solders requirement. No payments broadcast, runtime deployment, or independent adoption claimed.
